### PR TITLE
ouverture des campagnes bêta aux lecteurs non invités

### DIFF
--- a/docker/postgres/seed-test-data.sql
+++ b/docker/postgres/seed-test-data.sql
@@ -6,7 +6,8 @@ BEGIN;
 -- Front/back manual test accounts:
 -- - Write tab: alice.author@plumora.test / password
 -- - Reader library: clara.reader@plumora.test / password
--- - Beta reading: noah.beta@plumora.test / password
+-- - Beta reading: noah.beta@plumora.test / password (has invitations)
+-- - Beta reading (no invitation, open-access test): theo.beta@plumora.test / password
 -- - Admin: admin@plumora.test / password
 --
 -- Expected UI split:
@@ -26,7 +27,8 @@ VALUES
     ('10000000-0000-4000-8000-000000000005'),
     ('10000000-0000-4000-8000-000000000006'),
     ('10000000-0000-4000-8000-000000000007'),
-    ('10000000-0000-4000-8000-000000000008')
+    ('10000000-0000-4000-8000-000000000008'),
+    ('10000000-0000-4000-8000-000000000009')
 ON CONFLICT (id_user) DO NOTHING;
 
 DELETE FROM ai_recommendation_results
@@ -478,6 +480,19 @@ VALUES
         TRUE,
         now() - interval '15 days',
         now()
+    ),
+    (
+        '10000000-0000-4000-8000-000000000009',
+        'Theo',
+        'Rimbaud',
+        'theo_beta',
+        'theo.beta@plumora.test',
+        '$2a$10$hitz6ikg/grYTEyhlMlzXe2tPujxA2vHpFKU8v14gcpEWVPZrtlkm',
+        'https://placehold.co/256x256?text=TR',
+        'Beta-lecteur jamais invite, utilise pour verifier l''acces ouvert aux campagnes actives.',
+        TRUE,
+        now() - interval '5 days',
+        now()
     )
 ON CONFLICT (email) DO UPDATE SET
     firstname = EXCLUDED.firstname,
@@ -495,7 +510,9 @@ WITH extra_assignments(email, role_name) AS (
         ('maya.author@plumora.test', 'AUTHOR'),
         ('maya.author@plumora.test', 'READER'),
         ('eli.reader@plumora.test', 'READER'),
-        ('admin@plumora.test', 'READER')
+        ('admin@plumora.test', 'READER'),
+        ('theo.beta@plumora.test', 'READER'),
+        ('theo.beta@plumora.test', 'BETA_READER')
 )
 INSERT INTO user_roles (id_user, id_role, assigned_at)
 SELECT u.id_user, r.id_role, now() - interval '15 days'

--- a/docs/app-swagger-test-plan.md
+++ b/docs/app-swagger-test-plan.md
@@ -143,16 +143,17 @@ Se connecter avec `clara.reader@plumora.test`.
 
 Utiliser `alice.author@plumora.test` puis `noah.beta@plumora.test`.
 
+Depuis la refonte du role beta-lecteur, l'acces en lecture/commentaire n'est plus conditionne par une invitation : tout utilisateur avec le role `BETA_READER` peut acceder a une campagne `ACTIVE`, voir ses chapitres partages et y commenter. L'invitation reste disponible pour que l'auteur notifie un lecteur en particulier, mais accepter/refuser n'a plus d'impact sur l'acces.
+
 | ID | Action dans l'app | Route attendue | Resultat attendu |
 | --- | --- | --- | --- |
-| APP-BETA-01 | Auteur cree une campagne beta | `POST /books/{bookId}/beta-campaigns` | Campagne `ACTIVE`. |
+| APP-BETA-01 | Auteur cree une campagne beta | `POST /books/{bookId}/beta-campaigns` | Campagne `ACTIVE`, tous les BETA_READER recoivent une notification `BETA_CAMPAIGN_OPEN`. |
 | APP-BETA-02 | Auteur partage des chapitres | `PUT /beta-campaigns/{campaignId}/chapters` | Seuls les chapitres choisis sont exposes. |
-| APP-BETA-03 | Auteur invite Noah | `POST /beta-campaigns/{campaignId}/invitations` | Invitation `PENDING`, notification creee. |
-| APP-BETA-04 | Noah ouvre ses invitations | `GET /beta-invitations/my-invitations` | Invitation visible. |
-| APP-BETA-05 | Noah accepte | `PATCH /beta-invitations/{invitationId}/accept` | Invitation `ACCEPTED`. |
-| APP-BETA-06 | Noah voit les chapitres partages | `GET /beta-campaigns/{campaignId}/chapters` | Pas d'acces aux chapitres non partages. |
-| APP-BETA-07 | Noah cree un commentaire structure | `POST /beta-comments` | Commentaire `OPEN`, type/priorite/status visibles. |
-| APP-BETA-08 | Auteur voit et traite le commentaire | `GET /books/{bookId}/beta-comments`, `PATCH /beta-comments/{commentId}/status` | Statut mis a jour. |
+| APP-BETA-03 | Noah decouvre les campagnes ouvertes | `GET /beta-campaigns` | La campagne d'Alice apparait, sans avoir ete invite. |
+| APP-BETA-04 | Auteur invite Noah en plus (optionnel) | `POST /beta-campaigns/{campaignId}/invitations` | Invitation `PENDING`, notification ciblee creee. |
+| APP-BETA-05 | Noah voit les chapitres partages | `GET /beta-campaigns/{campaignId}/chapters` | Acces autorise sans invitation prealable ; pas d'acces aux chapitres non partages. |
+| APP-BETA-06 | Noah cree un commentaire structure | `POST /beta-comments` | Commentaire `OPEN`, type/priorite/status visibles. |
+| APP-BETA-07 | Auteur voit et traite le commentaire | `GET /books/{bookId}/beta-comments`, `PATCH /beta-comments/{commentId}/status` | Statut mis a jour. |
 
 ### 7. IA
 
@@ -191,7 +192,7 @@ Utiliser `alice.author@plumora.test` puis `noah.beta@plumora.test`.
 | --- | --- | --- |
 | APP-SEC-01 | Lecteur tente d'ouvrir une route auteur | L'action est cachee ou retourne une erreur 403 lisible. |
 | APP-SEC-02 | Auteur tente de modifier un livre d'un autre auteur | Erreur 403, aucune mutation. |
-| APP-SEC-03 | Beta-reader non invite tente d'ouvrir une campagne | Erreur 403, aucun chapitre affiche. |
+| APP-SEC-03 | Utilisateur sans role BETA_READER tente d'ouvrir une campagne ou d'y commenter | Erreur 403, aucun chapitre ni commentaire affiche. |
 | APP-SEC-04 | Lecteur tente favoris/review sur livre non publie | Erreur metier, action bloquee. |
 | APP-SEC-05 | Token expire ou invalide | Retour login ou refresh gere proprement selon l'app. |
 
@@ -399,9 +400,15 @@ Avec le token auteur :
 }
 ```
 
-Attendu : `201`, `status=ACTIVE`.
+Attendu : `201`, `status=ACTIVE`. Chaque utilisateur avec le role `BETA_READER` recoit une notification `BETA_CAMPAIGN_OPEN` (verifiable avec le token Noah sur `GET /notifications/my`).
 
 Noter `campaignId`.
+
+Avec le token Noah (sans invitation) :
+
+`GET /beta-campaigns`
+
+Attendu : `200`, la campagne d'Alice apparait dans la liste.
 
 ### 15. Partager chapitre
 
@@ -417,7 +424,9 @@ Noter `campaignId`.
 
 Attendu : liste contenant le chapitre.
 
-### 16. Inviter beta-reader
+### 16. Inviter beta-reader (optionnel)
+
+L'invitation ne conditionne plus l'acces (Noah peut deja lire et commenter grace a son role `BETA_READER`) ; elle sert uniquement a notifier un lecteur en particulier.
 
 Il faut connaitre l'id de Noah. Le plus simple :
 
@@ -438,7 +447,7 @@ Attendu : `201`, `status=PENDING`.
 
 Noter `invitationId`.
 
-### 17. Accepter invitation
+### 17. Accepter invitation (optionnel)
 
 Avec le token Noah :
 
@@ -448,7 +457,7 @@ Attendu : invitation visible.
 
 `PATCH /beta-invitations/{invitationId}/accept`
 
-Attendu : `status=ACCEPTED`.
+Attendu : `status=ACCEPTED`. Sans faire cette etape, Noah peut deja acceder aux chapitres partages et commenter (verifiable en inversant l'ordre des etapes 17 et 18).
 
 ### 18. Commentaire beta
 
@@ -587,7 +596,7 @@ PATCH /admin/books/{bookId}/archive
 | SWG-NEG-06 | `POST /books/{bookId}/chapters` | `chapterOrder` deja utilise | `400`. |
 | SWG-NEG-07 | `PATCH /books/{bookId}/publish` | Livre sans chapitre | `400`. |
 | SWG-NEG-08 | `POST /books/{bookId}/favorites` | Livre non publie | `400`. |
-| SWG-NEG-09 | `POST /beta-comments` | Invitation non acceptee | `403`. |
+| SWG-NEG-09 | `POST /beta-comments` | Token d'un utilisateur sans role BETA_READER | `403`. |
 | SWG-NEG-10 | `POST /beta-comments` | Chapitre non partage | `400`. |
 | SWG-NEG-11 | `PATCH /reports/{reportId}/status` | Token non-admin | `403`. |
 | SWG-NEG-12 | `GET /catalog/books/{bookId}` | Livre archive ou prive | `404`. |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -146,6 +146,11 @@ AiSuggestionStatus:
 - responded_at TIMESTAMP
 - UNIQUE(campaign_id, beta_reader_id)
 
+Note:
+- any user holding the BETA_READER role can read the shared chapters and comment on any ACTIVE campaign; an invitation is no longer required to gain access.
+- invitations are now an optional way for the author to point a specific beta reader at a campaign (targeted notification); accepting/refusing an invitation has no effect on access.
+- when a campaign is created, every BETA_READER user (except the author) automatically receives a BETA_CAMPAIGN_OPEN notification.
+
 ### beta_shared_chapters
 - id_beta_shared_chapter UUID PK
 - campaign_id UUID FK beta_reading_campaigns(id_beta_reading_campaign)
@@ -264,6 +269,7 @@ ReportStatus:
 
 NotificationType:
 - BETA_INVITATION
+- BETA_CAMPAIGN_OPEN
 - BETA_COMMENT_RECEIVED
 - BOOK_PUBLISHED
 - BOOK_ARCHIVED

--- a/scripts/api-smoke-tests.ps1
+++ b/scripts/api-smoke-tests.ps1
@@ -734,6 +734,16 @@ $campaign = Test-Api -Name "POST /books/{bookId}/beta-campaigns" -Method POST -P
 }
 $campaignId = [string]$campaign.Json.id
 
+Test-Api -Name "GET /beta-campaigns as uninvited beta reader" -Method GET -Path "/beta-campaigns" -Token $betaReader.Token -Assert {
+	param($json)
+	Require-Any @($json) { param($item) [string]$item.id -eq $campaignId } "Beta reader should discover open campaigns without being invited."
+} | Out-Null
+
+Test-Api -Name "GET /beta-campaigns/{campaignId} as uninvited beta reader" -Method GET -Path "/beta-campaigns/$campaignId" -Token $betaReader.Token -Assert {
+	param($json)
+	Require ([string]$json.id -eq $campaignId) "Beta reader should access the campaign without being invited."
+} | Out-Null
+
 Test-Api -Name "GET /books/{bookId}/beta-campaigns" -Method GET -Path "/books/$bookId/beta-campaigns" -Token $author.Token -Assert {
 	param($json)
 	Require-Any @($json) { param($item) [string]$item.id -eq $campaignId } "Campaign is missing from book campaigns."

--- a/src/main/java/com/plumora/api/betaReading/application/BetaCommentService.java
+++ b/src/main/java/com/plumora/api/betaReading/application/BetaCommentService.java
@@ -59,6 +59,7 @@ public class BetaCommentService {
 		User betaReader = userService.getCurrentUser(currentUserEmail);
 		BetaReadingCampaign campaign = findCampaign(request.campaignId());
 		ensureBetaReaderAccess(betaReader);
+		ensureNotCampaignAuthor(currentUserEmail, campaign);
 		ensureActiveCampaign(campaign);
 		Chapter chapter = findCampaignChapter(campaign.getBook(), request.chapterId());
 		ensureChapterIsShared(campaign, chapter);
@@ -177,6 +178,12 @@ public class BetaCommentService {
 
 	private boolean isCampaignAuthor(String currentUserEmail, BetaReadingCampaign campaign) {
 		return campaign.getAuthor().getEmail().equals(currentUserEmail);
+	}
+
+	private void ensureNotCampaignAuthor(String currentUserEmail, BetaReadingCampaign campaign) {
+		if (isCampaignAuthor(currentUserEmail, campaign)) {
+			throw new UnauthorizedActionException("Authors cannot leave beta comments on their own campaign");
+		}
 	}
 
 	private void ensureCommentAuthor(String currentUserEmail, BetaComment comment) {

--- a/src/main/java/com/plumora/api/betaReading/application/BetaCommentService.java
+++ b/src/main/java/com/plumora/api/betaReading/application/BetaCommentService.java
@@ -1,11 +1,10 @@
 package com.plumora.api.betaReading.application;
 
+import com.plumora.api.betaReading.domain.BetaCampaignStatus;
 import com.plumora.api.betaReading.domain.BetaComment;
 import com.plumora.api.betaReading.domain.BetaCommentStatus;
-import com.plumora.api.betaReading.domain.BetaInvitationStatus;
 import com.plumora.api.betaReading.domain.BetaReadingCampaign;
 import com.plumora.api.betaReading.infrastructure.BetaCommentRepository;
-import com.plumora.api.betaReading.infrastructure.BetaInvitationRepository;
 import com.plumora.api.betaReading.infrastructure.BetaReadingCampaignRepository;
 import com.plumora.api.betaReading.infrastructure.BetaSharedChapterRepository;
 import com.plumora.api.betaReading.presentation.CreateBetaCommentRequest;
@@ -19,6 +18,7 @@ import com.plumora.api.shared.exception.BusinessException;
 import com.plumora.api.shared.exception.ResourceNotFoundException;
 import com.plumora.api.shared.exception.UnauthorizedActionException;
 import com.plumora.api.user.application.UserService;
+import com.plumora.api.user.domain.RoleName;
 import com.plumora.api.user.domain.User;
 import java.util.List;
 import java.util.UUID;
@@ -30,7 +30,6 @@ public class BetaCommentService {
 
 	private final BetaCommentRepository commentRepository;
 	private final BetaReadingCampaignRepository campaignRepository;
-	private final BetaInvitationRepository invitationRepository;
 	private final BetaSharedChapterRepository sharedChapterRepository;
 	private final ChapterRepository chapterRepository;
 	private final BookService bookService;
@@ -40,7 +39,6 @@ public class BetaCommentService {
 	public BetaCommentService(
 		BetaCommentRepository commentRepository,
 		BetaReadingCampaignRepository campaignRepository,
-		BetaInvitationRepository invitationRepository,
 		BetaSharedChapterRepository sharedChapterRepository,
 		ChapterRepository chapterRepository,
 		BookService bookService,
@@ -49,7 +47,6 @@ public class BetaCommentService {
 	) {
 		this.commentRepository = commentRepository;
 		this.campaignRepository = campaignRepository;
-		this.invitationRepository = invitationRepository;
 		this.sharedChapterRepository = sharedChapterRepository;
 		this.chapterRepository = chapterRepository;
 		this.bookService = bookService;
@@ -61,7 +58,8 @@ public class BetaCommentService {
 	public BetaComment createComment(String currentUserEmail, CreateBetaCommentRequest request) {
 		User betaReader = userService.getCurrentUser(currentUserEmail);
 		BetaReadingCampaign campaign = findCampaign(request.campaignId());
-		ensureAcceptedInvitation(betaReader, campaign);
+		ensureBetaReaderAccess(betaReader);
+		ensureActiveCampaign(campaign);
 		Chapter chapter = findCampaignChapter(campaign.getBook(), request.chapterId());
 		ensureChapterIsShared(campaign, chapter);
 		ensureValidPositions(request.positionStart(), request.positionEnd());
@@ -96,7 +94,7 @@ public class BetaCommentService {
 		if (isCampaignAuthor(currentUserEmail, campaign)) {
 			return commentRepository.findByCampaignOrderByCreatedAtDesc(campaign);
 		}
-		ensureAcceptedInvitation(currentUser, campaign);
+		ensureBetaReaderAccess(currentUser);
 		return commentRepository.findByCampaignAndBetaReaderOrderByCreatedAtDesc(campaign, currentUser);
 	}
 
@@ -153,9 +151,15 @@ public class BetaCommentService {
 			.orElseThrow(() -> new BusinessException("Commented chapter must belong to the campaign book"));
 	}
 
-	private void ensureAcceptedInvitation(User betaReader, BetaReadingCampaign campaign) {
-		if (invitationRepository.findByCampaignAndBetaReaderAndStatus(campaign, betaReader, BetaInvitationStatus.ACCEPTED).isEmpty()) {
-			throw new UnauthorizedActionException("Only accepted beta readers can comment in this campaign");
+	private void ensureBetaReaderAccess(User user) {
+		if (!user.hasRole(RoleName.BETA_READER)) {
+			throw new UnauthorizedActionException("Only beta readers can access this beta-reading campaign");
+		}
+	}
+
+	private void ensureActiveCampaign(BetaReadingCampaign campaign) {
+		if (campaign.getStatus() != BetaCampaignStatus.ACTIVE) {
+			throw new BusinessException("Beta comments can only be added to active beta-reading campaigns");
 		}
 	}
 

--- a/src/main/java/com/plumora/api/betaReading/application/BetaReadingService.java
+++ b/src/main/java/com/plumora/api/betaReading/application/BetaReadingService.java
@@ -76,7 +76,16 @@ public class BetaReadingService {
 		campaign.setInstructions(request.instructions());
 		campaign.setDeadline(request.deadline());
 		campaign.setStatus(BetaCampaignStatus.ACTIVE);
-		return campaignRepository.save(campaign);
+		BetaReadingCampaign savedCampaign = campaignRepository.save(campaign);
+
+		notifyBetaReaders(savedCampaign);
+
+		return savedCampaign;
+	}
+
+	@Transactional(readOnly = true)
+	public List<BetaReadingCampaign> getOpenCampaigns() {
+		return campaignRepository.findByStatusOrderByCreatedAtDesc(BetaCampaignStatus.ACTIVE);
 	}
 
 	@Transactional(readOnly = true)
@@ -89,10 +98,10 @@ public class BetaReadingService {
 	public BetaReadingCampaign getCampaign(String currentUserEmail, UUID campaignId) {
 		User currentUser = userService.getCurrentUser(currentUserEmail);
 		BetaReadingCampaign campaign = findCampaign(campaignId);
-		if (isCampaignAuthor(currentUserEmail, campaign) || isInvited(currentUser, campaign)) {
+		if (isCampaignAuthor(currentUserEmail, campaign) || currentUser.hasRole(RoleName.BETA_READER)) {
 			return campaign;
 		}
-		throw new UnauthorizedActionException("Only the author or invited beta readers can access this campaign");
+		throw new UnauthorizedActionException("Only the author or beta readers can access this campaign");
 	}
 
 	@Transactional
@@ -177,7 +186,7 @@ public class BetaReadingService {
 		User currentUser = userService.getCurrentUser(currentUserEmail);
 		BetaReadingCampaign campaign = findCampaign(campaignId);
 		if (!isCampaignAuthor(currentUserEmail, campaign)) {
-			ensureAcceptedInvitation(currentUser, campaign);
+			ensureBetaReaderAccess(currentUser);
 		}
 		return sharedChapterRepository.findByCampaignOrderByChapterChapterOrderAsc(campaign)
 			.stream()
@@ -235,14 +244,21 @@ public class BetaReadingService {
 		return campaign.getAuthor().getEmail().equals(currentUserEmail);
 	}
 
-	private boolean isInvited(User user, BetaReadingCampaign campaign) {
-		return invitationRepository.findByCampaignAndBetaReader(campaign, user).isPresent();
+	private void ensureBetaReaderAccess(User user) {
+		if (!user.hasRole(RoleName.BETA_READER)) {
+			throw new UnauthorizedActionException("Only beta readers can access shared chapters");
+		}
 	}
 
-	private void ensureAcceptedInvitation(User user, BetaReadingCampaign campaign) {
-		if (invitationRepository.findByCampaignAndBetaReaderAndStatus(campaign, user, BetaInvitationStatus.ACCEPTED).isEmpty()) {
-			throw new UnauthorizedActionException("Only accepted beta readers can access shared chapters");
-		}
+	private void notifyBetaReaders(BetaReadingCampaign campaign) {
+		userRepository.findAllByRoles_Name(RoleName.BETA_READER).stream()
+			.filter(betaReader -> !betaReader.getId().equals(campaign.getAuthor().getId()))
+			.forEach(betaReader -> notificationService.createNotification(
+				betaReader,
+				"Nouvelle campagne de beta-lecture",
+				campaign.getAuthor().getUsername() + " a ouvert une campagne de beta-lecture pour \"" + campaign.getBook().getTitle() + "\".",
+				NotificationType.BETA_CAMPAIGN_OPEN
+			));
 	}
 
 	private void ensureInvitationReader(String currentUserEmail, BetaInvitation invitation) {
@@ -264,9 +280,7 @@ public class BetaReadingService {
 	}
 
 	private void ensureBetaReaderRole(User user) {
-		boolean betaReader = user.getRoles().stream()
-			.anyMatch(role -> role.getName() == RoleName.BETA_READER);
-		if (!betaReader) {
+		if (!user.hasRole(RoleName.BETA_READER)) {
 			throw new BusinessException("Invited user must have the BETA_READER role");
 		}
 	}

--- a/src/main/java/com/plumora/api/betaReading/application/BetaReadingService.java
+++ b/src/main/java/com/plumora/api/betaReading/application/BetaReadingService.java
@@ -84,8 +84,11 @@ public class BetaReadingService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<BetaReadingCampaign> getOpenCampaigns() {
-		return campaignRepository.findByStatusOrderByCreatedAtDesc(BetaCampaignStatus.ACTIVE);
+	public List<BetaReadingCampaign> getOpenCampaigns(String currentUserEmail) {
+		return campaignRepository.findByStatusOrderByCreatedAtDesc(BetaCampaignStatus.ACTIVE)
+			.stream()
+			.filter(campaign -> !isCampaignAuthor(currentUserEmail, campaign))
+			.toList();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/plumora/api/betaReading/infrastructure/BetaInvitationRepository.java
+++ b/src/main/java/com/plumora/api/betaReading/infrastructure/BetaInvitationRepository.java
@@ -1,7 +1,6 @@
 package com.plumora.api.betaReading.infrastructure;
 
 import com.plumora.api.betaReading.domain.BetaInvitation;
-import com.plumora.api.betaReading.domain.BetaInvitationStatus;
 import com.plumora.api.betaReading.domain.BetaReadingCampaign;
 import com.plumora.api.user.domain.User;
 import java.util.List;
@@ -18,12 +17,6 @@ public interface BetaInvitationRepository extends JpaRepository<BetaInvitation, 
 
 	@EntityGraph(attributePaths = {"campaign", "campaign.book", "campaign.author", "betaReader"})
 	List<BetaInvitation> findByBetaReaderOrderByInvitedAtDesc(User betaReader);
-
-	@EntityGraph(attributePaths = {"campaign", "campaign.book", "campaign.author", "betaReader"})
-	Optional<BetaInvitation> findByCampaignAndBetaReader(BetaReadingCampaign campaign, User betaReader);
-
-	@EntityGraph(attributePaths = {"campaign", "campaign.book", "campaign.author", "betaReader"})
-	Optional<BetaInvitation> findByCampaignAndBetaReaderAndStatus(BetaReadingCampaign campaign, User betaReader, BetaInvitationStatus status);
 
 	@EntityGraph(attributePaths = {"campaign", "campaign.book", "campaign.author", "betaReader"})
 	@Query("select i from BetaInvitation i where i.id = :id")

--- a/src/main/java/com/plumora/api/betaReading/infrastructure/BetaReadingCampaignRepository.java
+++ b/src/main/java/com/plumora/api/betaReading/infrastructure/BetaReadingCampaignRepository.java
@@ -1,5 +1,6 @@
 package com.plumora.api.betaReading.infrastructure;
 
+import com.plumora.api.betaReading.domain.BetaCampaignStatus;
 import com.plumora.api.betaReading.domain.BetaReadingCampaign;
 import com.plumora.api.book.domain.Book;
 import java.util.List;
@@ -13,6 +14,9 @@ import org.springframework.data.repository.query.Param;
 public interface BetaReadingCampaignRepository extends JpaRepository<BetaReadingCampaign, UUID> {
 	@EntityGraph(attributePaths = {"book", "author"})
 	List<BetaReadingCampaign> findByBookOrderByCreatedAtDesc(Book book);
+
+	@EntityGraph(attributePaths = {"book", "author"})
+	List<BetaReadingCampaign> findByStatusOrderByCreatedAtDesc(BetaCampaignStatus status);
 
 	@EntityGraph(attributePaths = {"book", "author"})
 	@Query("select c from BetaReadingCampaign c where c.id = :id")

--- a/src/main/java/com/plumora/api/betaReading/presentation/BetaCampaignController.java
+++ b/src/main/java/com/plumora/api/betaReading/presentation/BetaCampaignController.java
@@ -46,6 +46,15 @@ public class BetaCampaignController {
 			.toList();
 	}
 
+	@GetMapping("/beta-campaigns")
+	@PreAuthorize("hasRole('BETA_READER')")
+	public List<BetaCampaignResponse> getOpenCampaigns() {
+		return betaReadingService.getOpenCampaigns()
+			.stream()
+			.map(BetaReadingMapper::toCampaignResponse)
+			.toList();
+	}
+
 	@GetMapping("/beta-campaigns/{campaignId}")
 	@PreAuthorize("hasAnyRole('AUTHOR', 'BETA_READER')")
 	public BetaCampaignResponse getCampaign(Principal principal, @PathVariable UUID campaignId) {

--- a/src/main/java/com/plumora/api/betaReading/presentation/BetaCampaignController.java
+++ b/src/main/java/com/plumora/api/betaReading/presentation/BetaCampaignController.java
@@ -48,8 +48,8 @@ public class BetaCampaignController {
 
 	@GetMapping("/beta-campaigns")
 	@PreAuthorize("hasRole('BETA_READER')")
-	public List<BetaCampaignResponse> getOpenCampaigns() {
-		return betaReadingService.getOpenCampaigns()
+	public List<BetaCampaignResponse> getOpenCampaigns(Principal principal) {
+		return betaReadingService.getOpenCampaigns(principal.getName())
 			.stream()
 			.map(BetaReadingMapper::toCampaignResponse)
 			.toList();

--- a/src/main/java/com/plumora/api/notification/domain/NotificationType.java
+++ b/src/main/java/com/plumora/api/notification/domain/NotificationType.java
@@ -2,6 +2,7 @@ package com.plumora.api.notification.domain;
 
 public enum NotificationType {
 	BETA_INVITATION,
+	BETA_CAMPAIGN_OPEN,
 	BETA_COMMENT_RECEIVED,
 	BOOK_PUBLISHED,
 	BOOK_ARCHIVED,

--- a/src/main/java/com/plumora/api/user/application/UserService.java
+++ b/src/main/java/com/plumora/api/user/application/UserService.java
@@ -9,6 +9,7 @@ import com.plumora.api.user.domain.User;
 import com.plumora.api.user.infrastructure.RoleRepository;
 import com.plumora.api.user.infrastructure.UserRepository;
 import com.plumora.api.user.presentation.UpdateUserRequest;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -87,6 +88,18 @@ public class UserService {
 	@Transactional(readOnly = true)
 	public List<Role> getAllRoles() {
 		return roleRepository.findAll();
+	}
+
+	@Transactional(readOnly = true)
+	public List<User> findUsersByRole(RoleName roleName, String excludeEmail) {
+		if (roleName != RoleName.BETA_READER) {
+			throw new BusinessException("Only BETA_READER users can be listed through this endpoint");
+		}
+		return userRepository.findAllByRoles_Name(roleName)
+			.stream()
+			.filter(user -> !user.getEmail().equalsIgnoreCase(excludeEmail))
+			.sorted(Comparator.comparing(User::getUsername, String.CASE_INSENSITIVE_ORDER))
+			.collect(Collectors.toList());
 	}
 
 	private Role getRole(RoleName roleName) {

--- a/src/main/java/com/plumora/api/user/domain/User.java
+++ b/src/main/java/com/plumora/api/user/domain/User.java
@@ -69,6 +69,10 @@ public class User {
 	)
 	private Set<Role> roles = new HashSet<>();
 
+	public boolean hasRole(RoleName roleName) {
+		return roles.stream().anyMatch(role -> role.getName() == roleName);
+	}
+
 	@PrePersist
 	void onCreate() {
 		createdAt = LocalDateTime.now();

--- a/src/main/java/com/plumora/api/user/infrastructure/UserRepository.java
+++ b/src/main/java/com/plumora/api/user/infrastructure/UserRepository.java
@@ -1,5 +1,6 @@
 package com.plumora.api.user.infrastructure;
 
+import com.plumora.api.user.domain.RoleName;
 import com.plumora.api.user.domain.User;
 import java.util.List;
 import java.util.Optional;
@@ -8,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
 	List<User> findAllByOrderByCreatedAtDesc();
+
+	List<User> findAllByRoles_Name(RoleName roleName);
 
 	Optional<User> findByEmail(String email);
 

--- a/src/main/java/com/plumora/api/user/presentation/UserController.java
+++ b/src/main/java/com/plumora/api/user/presentation/UserController.java
@@ -1,16 +1,19 @@
 package com.plumora.api.user.presentation;
 
 import com.plumora.api.user.application.UserService;
+import com.plumora.api.user.domain.RoleName;
 import jakarta.validation.Valid;
 import java.security.Principal;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -55,6 +58,18 @@ public class UserController {
 			.stream()
 			.sorted(Comparator.comparing(role -> role.getName().name()))
 			.map(UserMapper::toRoleResponse)
+			.collect(Collectors.toList());
+	}
+
+	@GetMapping("/users")
+	@PreAuthorize("hasRole('AUTHOR')")
+	public List<UserSummaryResponse> getUsersByRole(
+		@RequestParam RoleName role,
+		Principal principal
+	) {
+		return userService.findUsersByRole(role, principal.getName())
+			.stream()
+			.map(UserMapper::toSummaryResponse)
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/plumora/api/user/presentation/UserMapper.java
+++ b/src/main/java/com/plumora/api/user/presentation/UserMapper.java
@@ -31,6 +31,10 @@ public final class UserMapper {
 		return new RoleResponse(role.getId(), role.getName(), role.getDescription());
 	}
 
+	public static UserSummaryResponse toSummaryResponse(User user) {
+		return new UserSummaryResponse(user.getId(), user.getUsername());
+	}
+
 	public static Set<RoleResponse> toRoleResponses(Set<Role> roles) {
 		return roles.stream()
 			.sorted(Comparator.comparing(role -> role.getName().name()))

--- a/src/main/java/com/plumora/api/user/presentation/UserSummaryResponse.java
+++ b/src/main/java/com/plumora/api/user/presentation/UserSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.plumora.api.user.presentation;
+
+import java.util.UUID;
+
+public record UserSummaryResponse(
+	UUID id,
+	String username
+) {
+}

--- a/src/main/resources/db/migration/V16__add_uninvited_beta_reader.sql
+++ b/src/main/resources/db/migration/V16__add_uninvited_beta_reader.sql
@@ -1,0 +1,39 @@
+-- Third beta-reader demo account, seeded without any beta invitation.
+-- Used to verify that any user with the BETA_READER role can discover,
+-- read and comment on active campaigns without being individually invited.
+
+INSERT INTO users (id_user, firstname, lastname, username, email, password_hash, avatar_url, bio, is_active, created_at, updated_at)
+VALUES (
+	'10000000-0000-4000-8000-000000000009',
+	'Theo',
+	'Rimbaud',
+	'theo_beta',
+	'theo.beta@plumora.test',
+	'$2a$10$hitz6ikg/grYTEyhlMlzXe2tPujxA2vHpFKU8v14gcpEWVPZrtlkm',
+	'https://ui-avatars.com/api/?background=56309a&color=fff&name=Theo+Rimbaud',
+	'Beta-lecteur jamais invite, utilise pour verifier l''acces ouvert aux campagnes actives.',
+	TRUE,
+	now() - interval '5 days',
+	now()
+)
+ON CONFLICT (email) DO UPDATE SET
+	firstname = EXCLUDED.firstname,
+	lastname = EXCLUDED.lastname,
+	username = EXCLUDED.username,
+	password_hash = EXCLUDED.password_hash,
+	avatar_url = EXCLUDED.avatar_url,
+	bio = EXCLUDED.bio,
+	is_active = TRUE,
+	updated_at = now();
+
+WITH assignments(email, role_name) AS (
+	VALUES
+		('theo.beta@plumora.test', 'READER'),
+		('theo.beta@plumora.test', 'BETA_READER')
+)
+INSERT INTO user_roles (id_user, id_role, assigned_at)
+SELECT u.id_user, r.id_role, now() - interval '5 days'
+FROM assignments a
+JOIN users u ON u.email = a.email
+JOIN roles r ON r.name = a.role_name
+ON CONFLICT (id_user, id_role) DO NOTHING;

--- a/src/test/java/com/plumora/api/betaReading/application/BetaCommentServiceTest.java
+++ b/src/test/java/com/plumora/api/betaReading/application/BetaCommentServiceTest.java
@@ -12,11 +12,8 @@ import com.plumora.api.betaReading.domain.BetaComment;
 import com.plumora.api.betaReading.domain.BetaCommentFeedbackType;
 import com.plumora.api.betaReading.domain.BetaCommentPriority;
 import com.plumora.api.betaReading.domain.BetaCommentStatus;
-import com.plumora.api.betaReading.domain.BetaInvitation;
-import com.plumora.api.betaReading.domain.BetaInvitationStatus;
 import com.plumora.api.betaReading.domain.BetaReadingCampaign;
 import com.plumora.api.betaReading.infrastructure.BetaCommentRepository;
-import com.plumora.api.betaReading.infrastructure.BetaInvitationRepository;
 import com.plumora.api.betaReading.infrastructure.BetaReadingCampaignRepository;
 import com.plumora.api.betaReading.infrastructure.BetaSharedChapterRepository;
 import com.plumora.api.betaReading.presentation.CreateBetaCommentRequest;
@@ -28,6 +25,7 @@ import com.plumora.api.book.domain.Chapter;
 import com.plumora.api.book.infrastructure.ChapterRepository;
 import com.plumora.api.notification.application.NotificationService;
 import com.plumora.api.notification.domain.NotificationType;
+import com.plumora.api.shared.exception.BusinessException;
 import com.plumora.api.shared.exception.UnauthorizedActionException;
 import com.plumora.api.user.application.UserService;
 import com.plumora.api.user.domain.Role;
@@ -54,9 +52,6 @@ class BetaCommentServiceTest {
 	private BetaReadingCampaignRepository campaignRepository;
 
 	@Mock
-	private BetaInvitationRepository invitationRepository;
-
-	@Mock
 	private BetaSharedChapterRepository sharedChapterRepository;
 
 	@Mock
@@ -78,7 +73,6 @@ class BetaCommentServiceTest {
 		betaCommentService = new BetaCommentService(
 			commentRepository,
 			campaignRepository,
-			invitationRepository,
 			sharedChapterRepository,
 			chapterRepository,
 			bookService,
@@ -88,7 +82,7 @@ class BetaCommentServiceTest {
 	}
 
 	@Test
-	void invitedBetaReaderCanComment() {
+	void anyBetaReaderCanComment() {
 		User author = user("author@example.com", RoleName.AUTHOR);
 		User betaReader = user("reader@example.com", RoleName.BETA_READER);
 		BetaReadingCampaign campaign = campaign(author);
@@ -97,8 +91,6 @@ class BetaCommentServiceTest {
 
 		when(userService.getCurrentUser(betaReader.getEmail())).thenReturn(betaReader);
 		when(campaignRepository.findByIdWithBookAndAuthor(campaign.getId())).thenReturn(Optional.of(campaign));
-		when(invitationRepository.findByCampaignAndBetaReaderAndStatus(campaign, betaReader, BetaInvitationStatus.ACCEPTED))
-			.thenReturn(Optional.of(invitation(campaign, betaReader)));
 		when(chapterRepository.findByIdAndBook(chapter.getId(), campaign.getBook())).thenReturn(Optional.of(chapter));
 		when(sharedChapterRepository.existsByCampaignAndChapter(campaign, chapter)).thenReturn(true);
 		when(commentRepository.save(any(BetaComment.class))).thenAnswer(invocation -> {
@@ -122,21 +114,36 @@ class BetaCommentServiceTest {
 	}
 
 	@Test
-	void nonInvitedUserCannotComment() {
+	void userWithoutBetaReaderRoleCannotComment() {
+		User author = user("author@example.com", RoleName.AUTHOR);
+		User plainReader = user("plain@example.com", RoleName.READER);
+		BetaReadingCampaign campaign = campaign(author);
+		Chapter chapter = chapter(campaign.getBook());
+		CreateBetaCommentRequest request = createRequest(campaign.getId(), chapter.getId());
+
+		when(userService.getCurrentUser(plainReader.getEmail())).thenReturn(plainReader);
+		when(campaignRepository.findByIdWithBookAndAuthor(campaign.getId())).thenReturn(Optional.of(campaign));
+
+		assertThatThrownBy(() -> betaCommentService.createComment(plainReader.getEmail(), request))
+			.isInstanceOf(UnauthorizedActionException.class)
+			.hasMessage("Only beta readers can access this beta-reading campaign");
+	}
+
+	@Test
+	void commentIsRejectedOnClosedCampaign() {
 		User author = user("author@example.com", RoleName.AUTHOR);
 		User betaReader = user("reader@example.com", RoleName.BETA_READER);
 		BetaReadingCampaign campaign = campaign(author);
+		campaign.setStatus(BetaCampaignStatus.CLOSED);
 		Chapter chapter = chapter(campaign.getBook());
 		CreateBetaCommentRequest request = createRequest(campaign.getId(), chapter.getId());
 
 		when(userService.getCurrentUser(betaReader.getEmail())).thenReturn(betaReader);
 		when(campaignRepository.findByIdWithBookAndAuthor(campaign.getId())).thenReturn(Optional.of(campaign));
-		when(invitationRepository.findByCampaignAndBetaReaderAndStatus(campaign, betaReader, BetaInvitationStatus.ACCEPTED))
-			.thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> betaCommentService.createComment(betaReader.getEmail(), request))
-			.isInstanceOf(UnauthorizedActionException.class)
-			.hasMessage("Only accepted beta readers can comment in this campaign");
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("Beta comments can only be added to active beta-reading campaigns");
 	}
 
 	@Test
@@ -192,15 +199,6 @@ class BetaCommentServiceTest {
 		comment.setStatus(BetaCommentStatus.OPEN);
 		comment.setCreatedAt(LocalDateTime.now());
 		return comment;
-	}
-
-	private BetaInvitation invitation(BetaReadingCampaign campaign, User betaReader) {
-		BetaInvitation invitation = new BetaInvitation();
-		invitation.setId(UUID.randomUUID());
-		invitation.setCampaign(campaign);
-		invitation.setBetaReader(betaReader);
-		invitation.setStatus(BetaInvitationStatus.ACCEPTED);
-		return invitation;
 	}
 
 	private BetaReadingCampaign campaign(User author) {

--- a/src/test/java/com/plumora/api/betaReading/application/BetaCommentServiceTest.java
+++ b/src/test/java/com/plumora/api/betaReading/application/BetaCommentServiceTest.java
@@ -32,10 +32,11 @@ import com.plumora.api.user.domain.Role;
 import com.plumora.api.user.domain.RoleName;
 import com.plumora.api.user.domain.User;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -127,6 +128,21 @@ class BetaCommentServiceTest {
 		assertThatThrownBy(() -> betaCommentService.createComment(plainReader.getEmail(), request))
 			.isInstanceOf(UnauthorizedActionException.class)
 			.hasMessage("Only beta readers can access this beta-reading campaign");
+	}
+
+	@Test
+	void authorCannotCommentOnOwnCampaign() {
+		User author = userWithRoles("author@example.com", RoleName.AUTHOR, RoleName.BETA_READER);
+		BetaReadingCampaign campaign = campaign(author);
+		Chapter chapter = chapter(campaign.getBook());
+		CreateBetaCommentRequest request = createRequest(campaign.getId(), chapter.getId());
+
+		when(userService.getCurrentUser(author.getEmail())).thenReturn(author);
+		when(campaignRepository.findByIdWithBookAndAuthor(campaign.getId())).thenReturn(Optional.of(campaign));
+
+		assertThatThrownBy(() -> betaCommentService.createComment(author.getEmail(), request))
+			.isInstanceOf(UnauthorizedActionException.class)
+			.hasMessage("Authors cannot leave beta comments on their own campaign");
 	}
 
 	@Test
@@ -234,15 +250,23 @@ class BetaCommentServiceTest {
 	}
 
 	private User user(String email, RoleName roleName) {
+		return userWithRoles(email, roleName);
+	}
+
+	private User userWithRoles(String email, RoleName... roleNames) {
 		User user = new User();
 		user.setId(UUID.randomUUID());
 		user.setFirstname("Test");
 		user.setLastname("User");
 		user.setEmail(email);
 		user.setUsername(email.substring(0, email.indexOf('@')));
-		Role role = new Role(roleName, roleName.name());
-		role.setId(UUID.randomUUID());
-		user.setRoles(Set.of(role));
+		user.setRoles(Arrays.stream(roleNames)
+			.map(roleName -> {
+				Role role = new Role(roleName, roleName.name());
+				role.setId(UUID.randomUUID());
+				return role;
+			})
+			.collect(Collectors.toSet()));
 		return user;
 	}
 }

--- a/src/test/java/com/plumora/api/betaReading/application/BetaReadingServiceTest.java
+++ b/src/test/java/com/plumora/api/betaReading/application/BetaReadingServiceTest.java
@@ -105,6 +105,7 @@ class BetaReadingServiceTest {
 			campaign.setId(UUID.randomUUID());
 			return campaign;
 		});
+		when(userRepository.findAllByRoles_Name(RoleName.BETA_READER)).thenReturn(List.of());
 
 		BetaReadingCampaign campaign = betaReadingService.createCampaign(author.getEmail(), book.getId(), request);
 
@@ -112,6 +113,78 @@ class BetaReadingServiceTest {
 		assertThat(campaign.getAuthor()).isEqualTo(author);
 		assertThat(campaign.getTitle()).isEqualTo("First beta");
 		assertThat(campaign.getStatus()).isEqualTo(BetaCampaignStatus.ACTIVE);
+	}
+
+	@Test
+	void createCampaignNotifiesAllBetaReadersExceptAuthor() {
+		User author = user("author@example.com", RoleName.AUTHOR);
+		Book book = book(author);
+		User betaReaderOne = user("reader1@example.com", RoleName.BETA_READER);
+		User betaReaderTwo = user("reader2@example.com", RoleName.BETA_READER);
+		CreateBetaCampaignRequest request = new CreateBetaCampaignRequest("First beta", "Instructions", null);
+
+		when(bookService.getOwnedEditableBook(author.getEmail(), book.getId())).thenReturn(book);
+		when(campaignRepository.save(any(BetaReadingCampaign.class))).thenAnswer(invocation -> {
+			BetaReadingCampaign campaign = invocation.getArgument(0);
+			campaign.setId(UUID.randomUUID());
+			return campaign;
+		});
+		when(userRepository.findAllByRoles_Name(RoleName.BETA_READER)).thenReturn(List.of(betaReaderOne, betaReaderTwo));
+
+		betaReadingService.createCampaign(author.getEmail(), book.getId(), request);
+
+		verify(notificationService).createNotification(
+			eq(betaReaderOne),
+			any(String.class),
+			any(String.class),
+			eq(NotificationType.BETA_CAMPAIGN_OPEN)
+		);
+		verify(notificationService).createNotification(
+			eq(betaReaderTwo),
+			any(String.class),
+			any(String.class),
+			eq(NotificationType.BETA_CAMPAIGN_OPEN)
+		);
+	}
+
+	@Test
+	void getOpenCampaignsReturnsActiveCampaigns() {
+		User author = user("author@example.com", RoleName.AUTHOR);
+		BetaReadingCampaign campaign = campaign(author);
+
+		when(campaignRepository.findByStatusOrderByCreatedAtDesc(BetaCampaignStatus.ACTIVE)).thenReturn(List.of(campaign));
+
+		List<BetaReadingCampaign> openCampaigns = betaReadingService.getOpenCampaigns();
+
+		assertThat(openCampaigns).containsExactly(campaign);
+	}
+
+	@Test
+	void getCampaignAllowsAnyBetaReaderWithoutInvitation() {
+		User author = user("author@example.com", RoleName.AUTHOR);
+		User betaReader = user("reader@example.com", RoleName.BETA_READER);
+		BetaReadingCampaign campaign = campaign(author);
+
+		when(userService.getCurrentUser(betaReader.getEmail())).thenReturn(betaReader);
+		when(campaignRepository.findByIdWithBookAndAuthor(campaign.getId())).thenReturn(Optional.of(campaign));
+
+		BetaReadingCampaign result = betaReadingService.getCampaign(betaReader.getEmail(), campaign.getId());
+
+		assertThat(result).isEqualTo(campaign);
+	}
+
+	@Test
+	void getCampaignRejectsUserWithoutBetaReaderRole() {
+		User author = user("author@example.com", RoleName.AUTHOR);
+		User plainReader = user("plain@example.com", RoleName.READER);
+		BetaReadingCampaign campaign = campaign(author);
+
+		when(userService.getCurrentUser(plainReader.getEmail())).thenReturn(plainReader);
+		when(campaignRepository.findByIdWithBookAndAuthor(campaign.getId())).thenReturn(Optional.of(campaign));
+
+		assertThatThrownBy(() -> betaReadingService.getCampaign(plainReader.getEmail(), campaign.getId()))
+			.isInstanceOf(UnauthorizedActionException.class)
+			.hasMessage("Only the author or beta readers can access this campaign");
 	}
 
 	@Test
@@ -206,23 +279,21 @@ class BetaReadingServiceTest {
 	}
 
 	@Test
-	void getSharedChaptersRequiresAcceptedInvitationForBetaReader() {
+	void getSharedChaptersRejectsUserWithoutBetaReaderRole() {
 		User author = user("author@example.com", RoleName.AUTHOR);
-		User betaReader = user("reader@example.com", RoleName.BETA_READER);
+		User plainReader = user("plain@example.com", RoleName.READER);
 		BetaReadingCampaign campaign = campaign(author);
 
-		when(userService.getCurrentUser(betaReader.getEmail())).thenReturn(betaReader);
+		when(userService.getCurrentUser(plainReader.getEmail())).thenReturn(plainReader);
 		when(campaignRepository.findByIdWithBookAndAuthor(campaign.getId())).thenReturn(Optional.of(campaign));
-		when(invitationRepository.findByCampaignAndBetaReaderAndStatus(campaign, betaReader, BetaInvitationStatus.ACCEPTED))
-			.thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> betaReadingService.getSharedChapters(betaReader.getEmail(), campaign.getId()))
+		assertThatThrownBy(() -> betaReadingService.getSharedChapters(plainReader.getEmail(), campaign.getId()))
 			.isInstanceOf(UnauthorizedActionException.class)
-			.hasMessage("Only accepted beta readers can access shared chapters");
+			.hasMessage("Only beta readers can access shared chapters");
 	}
 
 	@Test
-	void getSharedChaptersReturnsSharedChaptersForAcceptedBetaReader() {
+	void getSharedChaptersReturnsSharedChaptersForAnyBetaReader() {
 		User author = user("author@example.com", RoleName.AUTHOR);
 		User betaReader = user("reader@example.com", RoleName.BETA_READER);
 		BetaReadingCampaign campaign = campaign(author);
@@ -233,8 +304,6 @@ class BetaReadingServiceTest {
 
 		when(userService.getCurrentUser(betaReader.getEmail())).thenReturn(betaReader);
 		when(campaignRepository.findByIdWithBookAndAuthor(campaign.getId())).thenReturn(Optional.of(campaign));
-		when(invitationRepository.findByCampaignAndBetaReaderAndStatus(campaign, betaReader, BetaInvitationStatus.ACCEPTED))
-			.thenReturn(Optional.of(invitation(betaReader, BetaInvitationStatus.ACCEPTED)));
 		when(sharedChapterRepository.findByCampaignOrderByChapterChapterOrderAsc(campaign)).thenReturn(List.of(sharedChapter));
 
 		List<Chapter> chapters = betaReadingService.getSharedChapters(betaReader.getEmail(), campaign.getId());

--- a/src/test/java/com/plumora/api/betaReading/application/BetaReadingServiceTest.java
+++ b/src/test/java/com/plumora/api/betaReading/application/BetaReadingServiceTest.java
@@ -148,15 +148,28 @@ class BetaReadingServiceTest {
 	}
 
 	@Test
-	void getOpenCampaignsReturnsActiveCampaigns() {
+	void getOpenCampaignsReturnsActiveCampaignsForOtherUsers() {
+		User author = user("author@example.com", RoleName.AUTHOR);
+		User otherReader = user("reader@example.com", RoleName.BETA_READER);
+		BetaReadingCampaign campaign = campaign(author);
+
+		when(campaignRepository.findByStatusOrderByCreatedAtDesc(BetaCampaignStatus.ACTIVE)).thenReturn(List.of(campaign));
+
+		List<BetaReadingCampaign> openCampaigns = betaReadingService.getOpenCampaigns(otherReader.getEmail());
+
+		assertThat(openCampaigns).containsExactly(campaign);
+	}
+
+	@Test
+	void getOpenCampaignsExcludesCampaignsAuthoredByCurrentUser() {
 		User author = user("author@example.com", RoleName.AUTHOR);
 		BetaReadingCampaign campaign = campaign(author);
 
 		when(campaignRepository.findByStatusOrderByCreatedAtDesc(BetaCampaignStatus.ACTIVE)).thenReturn(List.of(campaign));
 
-		List<BetaReadingCampaign> openCampaigns = betaReadingService.getOpenCampaigns();
+		List<BetaReadingCampaign> openCampaigns = betaReadingService.getOpenCampaigns(author.getEmail());
 
-		assertThat(openCampaigns).containsExactly(campaign);
+		assertThat(openCampaigns).isEmpty();
 	}
 
 	@Test

--- a/src/test/java/com/plumora/api/user/application/UserServiceTest.java
+++ b/src/test/java/com/plumora/api/user/application/UserServiceTest.java
@@ -1,0 +1,71 @@
+package com.plumora.api.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.plumora.api.shared.exception.BusinessException;
+import com.plumora.api.user.domain.Role;
+import com.plumora.api.user.domain.RoleName;
+import com.plumora.api.user.domain.User;
+import com.plumora.api.user.infrastructure.RoleRepository;
+import com.plumora.api.user.infrastructure.UserRepository;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private RoleRepository roleRepository;
+
+	private UserService userService;
+
+	@BeforeEach
+	void setUp() {
+		userService = new UserService(userRepository, roleRepository);
+	}
+
+	@Test
+	void findUsersByRoleReturnsBetaReadersExcludingCurrentUser() {
+		User caller = user("author@example.com", "author_zed");
+		User betaReaderA = user("beta.a@example.com", "beta_a");
+		User betaReaderB = user("beta.b@example.com", "beta_b");
+
+		when(userRepository.findAllByRoles_Name(RoleName.BETA_READER))
+			.thenReturn(List.of(betaReaderB, caller, betaReaderA));
+
+		List<User> result = userService.findUsersByRole(RoleName.BETA_READER, caller.getEmail());
+
+		assertThat(result).containsExactly(betaReaderA, betaReaderB);
+	}
+
+	@Test
+	void findUsersByRoleRejectsNonBetaReaderRoles() {
+		assertThatThrownBy(() -> userService.findUsersByRole(RoleName.ADMIN, "author@example.com"))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("Only BETA_READER users can be listed through this endpoint");
+	}
+
+	private User user(String email, String username) {
+		User user = new User();
+		user.setId(UUID.randomUUID());
+		user.setFirstname("Test");
+		user.setLastname("User");
+		user.setEmail(email);
+		user.setUsername(username);
+		Role role = new Role(RoleName.BETA_READER, "Can participate in beta-reading campaigns");
+		role.setId(UUID.randomUUID());
+		user.setRoles(Set.of(role));
+		return user;
+	}
+}


### PR DESCRIPTION
## Changements

- Ajout d'un endpoint pour lister les beta-lecteurs disponibles.
- Ouverture des campagnes beta actives aux beta-lecteurs sans invitation préalable.
- Exclusion de l'auteur de ses propres campagnes beta ouvertes.
- Blocage des commentaires beta déposés par l'auteur sur sa propre campagne.
- Ajout et mise à jour des tests de services beta-lecture.

## Pourquoi

Ce changement permet aux beta-lecteurs de découvrir les campagnes ouvertes, tout en évitant qu'un auteur puisse se comporter comme beta-lecteur sur sa propre campagne.

## Validation

- `git diff --check`: OK.
- `mvnw -Dtest=BetaCommentServiceTest,BetaReadingServiceTest test`: non exécuté, Java n'est pas disponible dans l'environnement (`JAVA_HOME` absent et `java` introuvable).