### PR TITLE
modele Gemini par defaut (gemini-2.5-flash-lite retire)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 HELP.md
 target/
 uploads/
+.env
+.env.*
+!.env.example
 !src/main/resources/static/uploads/
 !src/main/resources/static/uploads/book-covers/
 !src/main/resources/static/uploads/book-covers/plumora-*.png

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       PLUMORA_UPLOAD_DIR: ${PLUMORA_UPLOAD_DIR:-/app/uploads}
       AI_PROVIDER: ${AI_PROVIDER:-mock}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
-      GEMINI_MODEL: ${GEMINI_MODEL:-gemini-2.5-flash-lite}
+      GEMINI_MODEL: ${GEMINI_MODEL:-gemini-flash-lite-latest}
       GEMINI_TIMEOUT_SECONDS: ${GEMINI_TIMEOUT_SECONDS:-30}
       GEMINI_MAX_INPUT_CHARS: ${GEMINI_MAX_INPUT_CHARS:-12000}
     ports:

--- a/src/main/java/com/plumora/api/ai/infrastructure/provider/gemini/GeminiClient.java
+++ b/src/main/java/com/plumora/api/ai/infrastructure/provider/gemini/GeminiClient.java
@@ -30,7 +30,7 @@ public class GeminiClient {
 	public GeminiClient(
 		@Value("${app.external.gemini.base-url:https://generativelanguage.googleapis.com}") String baseUrl,
 		@Value("${app.external.gemini.api-key:}") String apiKey,
-		@Value("${app.external.gemini.model:gemini-2.5-flash-lite}") String model,
+		@Value("${app.external.gemini.model:gemini-flash-lite-latest}") String model,
 		@Value("${app.external.gemini.timeout-seconds:30}") int timeoutSeconds
 	) {
 		this(createRestClient(baseUrl, timeoutSeconds), apiKey, model);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,7 @@ app:
     gemini:
       base-url: ${GEMINI_BASE_URL:https://generativelanguage.googleapis.com}
       api-key: ${GEMINI_API_KEY:}
-      model: ${GEMINI_MODEL:gemini-2.5-flash-lite}
+      model: ${GEMINI_MODEL:gemini-flash-lite-latest}
       timeout-seconds: ${GEMINI_TIMEOUT_SECONDS:30}
   ai:
     max-input-chars: ${GEMINI_MAX_INPUT_CHARS:12000}


### PR DESCRIPTION
Teste en conditions reelles avec une vraie cle API : gemini-2.5-flash-lite renvoie 404 "no longer available to new users" cote Google. Remplace par l'alias gemini-flash-lite-latest (maintenu par Google, evite de refaire face au meme probleme au prochain retrait de modele).

Ajoute aussi .env au .gitignore (absent auparavant).

Valide en local avec une vraie cle Gemini sur les 6 endpoints Plumo IA (rewrite, summarize, continue, titles, beta-reading/analyze, books/recommend) : reponses reelles et coherentes, provider="gemini".