### PR TITLE
Ajout d'un modele de fichier d'environnement local pour la configurat…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Copier ce fichier en .env (ignore par git) et remplir les valeurs necessaires.
+# Toutes ces variables ont une valeur par defaut dans docker-compose.yml : ce fichier
+# ne sert qu'a les surcharger localement (ex. activer Gemini, changer le profil Spring).
+
+# Profils Spring actifs. Mettre "dev" pour activer le seed du compte admin de demonstration
+# (admin@plumora.local / Admin123!) - jamais active sans ce profil explicite.
+SPRING_PROFILES_ACTIVE=
+
+# Base de donnees PostgreSQL
+POSTGRES_DB=plumora_db
+POSTGRES_USER=plumora
+POSTGRES_PASSWORD=plumora
+
+# Authentification JWT
+JWT_SECRET=change-me-for-local-development-only
+JWT_EXPIRATION=86400000
+
+# Plumo IA - "mock" (reponses simulees, par defaut) ou "gemini" (necessite une cle API valide)
+AI_PROVIDER=mock
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-flash-lite-latest
+GEMINI_TIMEOUT_SECONDS=30
+GEMINI_MAX_INPUT_CHARS=12000

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ IA), et administration de la plateforme.
 
 ## Demarrer l'API en local
 
+Copier `.env.example` en `.env` (ignore par git) pour surcharger les variables locales si besoin
+(activer Gemini, changer le profil Spring, etc.), puis :
+
 ```bash
 docker compose up -d --build
 ```


### PR DESCRIPTION
…ion Docker Compose

Ajout .env.example documentant toutes les variables surchargeables (profil Spring, base de donnees, JWT, Plumo IA) deja protegees par .gitignore, et reference ce fichier dans le README pour rendre la configuration locale (notamment l'activation de Gemini) plus facile a decouvrir.