### PR TITLE
fix(deploy): add Caddy site block for the apex domain

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -45,6 +45,8 @@ GEMINI_MAX_INPUT_CHARS=12000
 CORS_ALLOWED_ORIGINS=https://app.plumora.fr
 
 # --- Domaines (Caddy) ---
+# Domaine racine (apex, sans sous-domaine) : redirige vers APP_DOMAIN, comme WWW_DOMAIN.
+ROOT_DOMAIN=plumora.fr
 APP_DOMAIN=app.plumora.fr
 API_DOMAIN=api.plumora.fr
 WWW_DOMAIN=www.plumora.fr

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -86,3 +86,11 @@
 	import security_headers
 	redir https://{$APP_DOMAIN}{uri} permanent
 }
+
+# plumora.fr (apex/racine, sans sous-domaine) - meme raisonnement que www.plumora.fr ci-dessus :
+# redirige vers l'app plutot que de laisser Caddy sans site correspondant pour ce nom (ce qui
+# ferait echouer la negociation TLS pour tout client presentant ce SNI, faute de certificat).
+{$ROOT_DOMAIN} {
+	import security_headers
+	redir https://{$APP_DOMAIN}{uri} permanent
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -61,8 +61,11 @@ Le reste de ce document suppose que `deploy/` se trouve a cet emplacement
 ## 3. DNS
 
 Avant le premier lancement, creer des enregistrements DNS **A** (et **AAAA** si IPv6) pointant
-vers l'IP du VPS pour les trois domaines :
+vers l'IP du VPS pour les quatre domaines :
 
+- `plumora.fr` (racine/apex) → optionnel (redirige vers `app.plumora.fr`, meme raison que
+  `www.plumora.fr` ci-dessous ; sans bloc Caddy dedie pour ce domaine, la negociation TLS
+  echoue pour tout client qui le contacte directement, voir [`Caddyfile`](Caddyfile))
 - `app.plumora.fr` → Flutter Web
 - `api.plumora.fr` → API Spring Boot
 - `www.plumora.fr` → optionnel (redirige vers `app.plumora.fr` tant qu'aucun site vitrine dedie
@@ -540,8 +543,8 @@ est absente de `.env`.
 
 Le reste (`COMPOSE_PROJECT_NAME`, `POSTGRES_DB`, `POSTGRES_USER`,
 `SPRING_PROFILES_ACTIVE`, `JWT_EXPIRATION`, `AI_PROVIDER`, `GEMINI_*`, `WWW_DOMAIN`,
-`BACKUP_RETENTION_DAYS`, `BACKUP_DIR`, `BACKUP_S3_BUCKET`) a une valeur par defaut raisonnable si
-absent de `.env` — voir [`.env.example`](.env.example) pour le detail.
+`ROOT_DOMAIN`, `BACKUP_RETENTION_DAYS`, `BACKUP_DIR`, `BACKUP_S3_BUCKET`) a une valeur par
+defaut raisonnable si absent de `.env` — voir [`.env.example`](.env.example) pour le detail.
 
 ## Premier deploiement : commandes exactes
 
@@ -565,6 +568,6 @@ docker compose --env-file .env -f compose.prod.yml config --quiet && echo OK
 - `JWT_SECRET` — aleatoire, au moins 32 caracteres (ex. `openssl rand -base64 48`).
 - `GEMINI_API_KEY` — uniquement si `AI_PROVIDER=gemini` ; laisser `AI_PROVIDER=mock` sinon (aucune
   cle requise dans ce cas).
-- `CORS_ALLOWED_ORIGINS`, `APP_DOMAIN`, `API_DOMAIN`, `WWW_DOMAIN` — confirmer qu'ils
-  correspondent exactement aux domaines DNS reellement pointes vers ce VPS.
+- `CORS_ALLOWED_ORIGINS`, `APP_DOMAIN`, `API_DOMAIN`, `WWW_DOMAIN`, `ROOT_DOMAIN` — confirmer
+  qu'ils correspondent exactement aux domaines DNS reellement pointes vers ce VPS.
 - `CADDY_ACME_EMAIL` — adresse email reelle pour les notifications Let's Encrypt.

--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -87,6 +87,7 @@ services:
       APP_DOMAIN: ${APP_DOMAIN:?APP_DOMAIN is required}
       API_DOMAIN: ${API_DOMAIN:?API_DOMAIN is required}
       WWW_DOMAIN: ${WWW_DOMAIN:-www.plumora.fr}
+      ROOT_DOMAIN: ${ROOT_DOMAIN:-plumora.fr}
       # Used only for Let's Encrypt expiry/account notifications, never for authentication.
       CADDY_ACME_EMAIL: ${CADDY_ACME_EMAIL:?CADDY_ACME_EMAIL is required}
     ports:


### PR DESCRIPTION
## Summary
- The `Caddyfile` only defined site blocks for `APP_DOMAIN`, `API_DOMAIN` and `WWW_DOMAIN`. The bare apex domain (e.g. `plumora.fr`) had no matching site, so Caddy has no certificate to present for that SNI and TLS negotiation fails for any client contacting it directly.
- Discovered during the first real production deployment: `app`/`api`/`www` all worked over HTTPS, the apex domain did not.
- Adds a `ROOT_DOMAIN` redirect block mirroring the existing `WWW_DOMAIN` one (redirects to `APP_DOMAIN`), wires it through `compose.prod.yml` (with a `plumora.fr` default, non-breaking for existing deployments), documents it in `.env.example` and `deploy/README.md`.

## Test plan
- [x] `docker compose --env-file .env -f compose.prod.yml config --quiet` still passes
- [ ] After merge, `git pull` + restart the `caddy` service on the VPS and confirm `https://plumora-books.fr` now returns a redirect to `https://app.plumora-books.fr` instead of failing TLS negotiation