### PR TITLE
feat(catalog): fall back to Open Library when Gutendex is unreachable

### DIFF
--- a/src/main/java/com/plumora/api/book/application/ExternalBookService.java
+++ b/src/main/java/com/plumora/api/book/application/ExternalBookService.java
@@ -13,7 +13,10 @@ import com.plumora.api.book.infrastructure.gutendex.GutendexBookResponse;
 import com.plumora.api.book.infrastructure.gutendex.GutendexClient;
 import com.plumora.api.book.infrastructure.gutendex.GutendexPageResponse;
 import com.plumora.api.book.infrastructure.gutendex.GutendexSearchRequest;
+import com.plumora.api.book.infrastructure.openlibrary.OpenLibraryClient;
 import com.plumora.api.book.infrastructure.openlibrary.OpenLibraryCoverService;
+import com.plumora.api.book.infrastructure.openlibrary.OpenLibraryDocResponse;
+import com.plumora.api.book.infrastructure.openlibrary.OpenLibrarySearchResponse;
 import com.plumora.api.shared.exception.BusinessException;
 import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
 import com.plumora.api.shared.exception.ResourceNotFoundException;
@@ -54,6 +57,7 @@ public class ExternalBookService {
 	private final GutendexClient gutendexClient;
 	private final GutendexContentClient gutendexContentClient;
 	private final ExternalBookContentSanitizer externalBookContentSanitizer;
+	private final OpenLibraryClient openLibraryClient;
 	private final OpenLibraryCoverService openLibraryCoverService;
 	private final BookRepository bookRepository;
 	private final ChapterRepository chapterRepository;
@@ -63,6 +67,7 @@ public class ExternalBookService {
 		GutendexClient gutendexClient,
 		GutendexContentClient gutendexContentClient,
 		ExternalBookContentSanitizer externalBookContentSanitizer,
+		OpenLibraryClient openLibraryClient,
 		OpenLibraryCoverService openLibraryCoverService,
 		BookRepository bookRepository,
 		ChapterRepository chapterRepository,
@@ -71,6 +76,7 @@ public class ExternalBookService {
 		this.gutendexClient = gutendexClient;
 		this.gutendexContentClient = gutendexContentClient;
 		this.externalBookContentSanitizer = externalBookContentSanitizer;
+		this.openLibraryClient = openLibraryClient;
 		this.openLibraryCoverService = openLibraryCoverService;
 		this.bookRepository = bookRepository;
 		this.chapterRepository = chapterRepository;
@@ -80,17 +86,35 @@ public class ExternalBookService {
 	@Transactional(readOnly = true)
 	public Page<ExternalBook> searchExternalBooks(String search, String language, String topic, int page) {
 		int safePage = Math.max(page, 0);
-		GutendexSearchRequest request = GutendexSearchRequest.publicDomain(
-			normalize(search),
-			normalize(language),
-			normalize(topic),
-			safePage + 1
-		);
-		GutendexPageResponse response = gutendexClient.searchBooks(request);
-		List<ExternalBook> books = safeResults(response).stream()
+		try {
+			GutendexSearchRequest request = GutendexSearchRequest.publicDomain(
+				normalize(search),
+				normalize(language),
+				normalize(topic),
+				safePage + 1
+			);
+			GutendexPageResponse response = gutendexClient.searchBooks(request);
+			List<ExternalBook> books = safeResults(response).stream()
+				.map(this::toExternalBook)
+				.toList();
+			long total = Math.max(response.count(), books.size());
+			return new PageImpl<>(books, PageRequest.of(safePage, GUTENDEX_PAGE_SIZE), total);
+		} catch (ExternalServiceUnavailableException exception) {
+			// Gutendex (gutendex.com) is unreachable - fall back to Open Library for discovery.
+			// Open Library is a metadata catalog, not a full-text source: results mapped from it
+			// never carry a readUrl/formats, so the app must not offer to import/read them, only
+			// browse (see toExternalBook(OpenLibraryDocResponse)).
+			return searchOpenLibraryBooks(normalize(search), normalize(topic), safePage);
+		}
+	}
+
+	private Page<ExternalBook> searchOpenLibraryBooks(String search, String topic, int safePage) {
+		OpenLibrarySearchResponse response = openLibraryClient.searchBooks(search, topic, safePage + 1);
+		List<ExternalBook> books = safeDocs(response).stream()
+			.filter(doc -> StringUtils.hasText(doc.title()))
 			.map(this::toExternalBook)
 			.toList();
-		long total = Math.max(response.count(), books.size());
+		long total = Math.max(response.numFound(), books.size());
 		return new PageImpl<>(books, PageRequest.of(safePage, GUTENDEX_PAGE_SIZE), total);
 	}
 
@@ -179,6 +203,48 @@ public class ExternalBookService {
 			importedBookId.isPresent(),
 			importedBookId.orElse(null)
 		);
+	}
+
+	private ExternalBook toExternalBook(OpenLibraryDocResponse doc) {
+		return new ExternalBook(
+			doc.key(),
+			"OPEN_LIBRARY",
+			doc.title(),
+			safeList(doc.authorName()),
+			null,
+			safeList(doc.subject()),
+			List.of(),
+			null,
+			null,
+			0,
+			openLibraryCoverUrl(doc),
+			null,
+			Map.of(),
+			StringUtils.hasText(doc.key()) ? "https://openlibrary.org" + doc.key() : null,
+			false,
+			null
+		);
+	}
+
+	private String openLibraryCoverUrl(OpenLibraryDocResponse doc) {
+		if (doc.coverId() != null) {
+			return "https://covers.openlibrary.org/b/id/" + doc.coverId() + "-L.jpg?default=false";
+		}
+		if (doc.isbn() != null) {
+			return doc.isbn().stream()
+				.filter(StringUtils::hasText)
+				.findFirst()
+				.map(isbn -> "https://covers.openlibrary.org/b/isbn/" + isbn + "-L.jpg?default=false")
+				.orElse(null);
+		}
+		return null;
+	}
+
+	private List<OpenLibraryDocResponse> safeDocs(OpenLibrarySearchResponse response) {
+		if (response == null || response.docs() == null) {
+			return List.of();
+		}
+		return response.docs();
 	}
 
 	private void ensureReadableChapter(Book book, int gutendexId) {

--- a/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClient.java
+++ b/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClient.java
@@ -1,0 +1,95 @@
+package com.plumora.api.book.infrastructure.openlibrary;
+
+import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * Discovery-only fallback used when Gutendex itself is unreachable (see ExternalBookService).
+ * Open Library is a metadata catalog, not a full-text source like Gutendex: results from here
+ * never carry a readUrl/formats, so they are never importable/readable in-app, only browsable.
+ */
+@Component
+public class OpenLibraryClient {
+
+	private static final Logger log = LoggerFactory.getLogger(OpenLibraryClient.class);
+	private static final String SEARCH_FIELDS = "key,title,author_name,cover_i,isbn,subject";
+	private static final int PAGE_SIZE = 32;
+
+	private final RestClient restClient;
+
+	@Autowired
+	public OpenLibraryClient(@Value("${app.external.open-library.base-url:https://openlibrary.org}") String baseUrl) {
+		this(createRestClient(baseUrl));
+	}
+
+	OpenLibraryClient(RestClient restClient) {
+		this.restClient = restClient;
+	}
+
+	public OpenLibrarySearchResponse searchBooks(String search, String subject, int page) {
+		try {
+			OpenLibrarySearchResponse response = restClient.get()
+				.uri(uriBuilder -> {
+					uriBuilder.path("/search.json")
+						.queryParam("fields", SEARCH_FIELDS)
+						.queryParam("limit", PAGE_SIZE)
+						.queryParam("page", Math.max(page, 1))
+						.queryParam("q", query(search, subject));
+					return uriBuilder.build();
+				})
+				.retrieve()
+				.body(OpenLibrarySearchResponse.class);
+			return response == null ? empty() : response;
+		} catch (RestClientResponseException exception) {
+			throw unavailable("Open Library search failed with status " + exception.getStatusCode().value(), exception);
+		} catch (ResourceAccessException exception) {
+			throw unavailable("Open Library search timed out or could not be reached", exception);
+		} catch (RestClientException exception) {
+			throw unavailable("Open Library search failed", exception);
+		}
+	}
+
+	private String query(String search, String subject) {
+		StringBuilder query = new StringBuilder();
+		if (StringUtils.hasText(search)) {
+			query.append(search.trim());
+		}
+		if (StringUtils.hasText(subject)) {
+			if (!query.isEmpty()) {
+				query.append(' ');
+			}
+			query.append("subject:").append(subject.trim());
+		}
+		return query.isEmpty() ? "*" : query.toString();
+	}
+
+	private OpenLibrarySearchResponse empty() {
+		return new OpenLibrarySearchResponse(0, List.of());
+	}
+
+	private static RestClient createRestClient(String baseUrl) {
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(3000);
+		requestFactory.setReadTimeout(5000);
+		return RestClient.builder()
+			.baseUrl(baseUrl)
+			.requestFactory(requestFactory)
+			.build();
+	}
+
+	private ExternalServiceUnavailableException unavailable(String message, Exception exception) {
+		log.warn(message, exception);
+		return new ExternalServiceUnavailableException("Open Library is currently unavailable");
+	}
+}

--- a/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryDocResponse.java
+++ b/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryDocResponse.java
@@ -3,13 +3,14 @@ package com.plumora.api.book.infrastructure.openlibrary;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-record OpenLibraryDocResponse(
+public record OpenLibraryDocResponse(
 	String key,
 	String title,
 	@JsonProperty("author_name")
 	List<String> authorName,
 	@JsonProperty("cover_i")
 	Integer coverId,
-	List<String> isbn
+	List<String> isbn,
+	List<String> subject
 ) {
 }

--- a/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibrarySearchResponse.java
+++ b/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibrarySearchResponse.java
@@ -1,8 +1,11 @@
 package com.plumora.api.book.infrastructure.openlibrary;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-record OpenLibrarySearchResponse(
+public record OpenLibrarySearchResponse(
+	@JsonProperty("numFound")
+	int numFound,
 	List<OpenLibraryDocResponse> docs
 ) {
 }

--- a/src/test/java/com/plumora/api/book/application/ExternalBookServiceTest.java
+++ b/src/test/java/com/plumora/api/book/application/ExternalBookServiceTest.java
@@ -21,8 +21,12 @@ import com.plumora.api.book.infrastructure.gutendex.GutendexClient;
 import com.plumora.api.book.infrastructure.gutendex.GutendexContentClient;
 import com.plumora.api.book.infrastructure.gutendex.GutendexPageResponse;
 import com.plumora.api.book.infrastructure.gutendex.GutendexSearchRequest;
+import com.plumora.api.book.infrastructure.openlibrary.OpenLibraryClient;
 import com.plumora.api.book.infrastructure.openlibrary.OpenLibraryCoverService;
+import com.plumora.api.book.infrastructure.openlibrary.OpenLibraryDocResponse;
+import com.plumora.api.book.infrastructure.openlibrary.OpenLibrarySearchResponse;
 import com.plumora.api.shared.exception.BusinessException;
+import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
 import com.plumora.api.user.application.UserService;
 import com.plumora.api.user.domain.User;
 import java.util.LinkedHashMap;
@@ -50,6 +54,9 @@ class ExternalBookServiceTest {
 	private ExternalBookContentSanitizer externalBookContentSanitizer;
 
 	@Mock
+	private OpenLibraryClient openLibraryClient;
+
+	@Mock
 	private OpenLibraryCoverService openLibraryCoverService;
 
 	@Mock
@@ -69,6 +76,7 @@ class ExternalBookServiceTest {
 			gutendexClient,
 			gutendexContentClient,
 			externalBookContentSanitizer,
+			openLibraryClient,
 			openLibraryCoverService,
 			bookRepository,
 			chapterRepository,
@@ -145,6 +153,38 @@ class ExternalBookServiceTest {
 
 		assertThat(book.imported()).isTrue();
 		assertThat(book.internalBookId()).isEqualTo(importedBook.getId());
+	}
+
+	@Test
+	void searchExternalBooksFallsBackToOpenLibraryWhenGutendexIsUnavailable() {
+		when(gutendexClient.searchBooks(any(GutendexSearchRequest.class)))
+			.thenThrow(new ExternalServiceUnavailableException("Gutendex is currently unavailable"));
+		OpenLibraryDocResponse doc = new OpenLibraryDocResponse(
+			"/works/OL1W",
+			"Les Miserables",
+			List.of("Victor Hugo"),
+			987,
+			null,
+			List.of("Fantasy")
+		);
+		when(openLibraryClient.searchBooks("Hugo", "fiction", 1))
+			.thenReturn(new OpenLibrarySearchResponse(1, List.of(doc)));
+
+		var page = externalBookService.searchExternalBooks(" Hugo ", "fr", " fiction ", 0);
+
+		ExternalBook book = page.getContent().getFirst();
+		assertThat(book.externalId()).isEqualTo("/works/OL1W");
+		assertThat(book.source()).isEqualTo("OPEN_LIBRARY");
+		assertThat(book.title()).isEqualTo("Les Miserables");
+		assertThat(book.authors()).containsExactly("Victor Hugo");
+		assertThat(book.subjects()).containsExactly("Fantasy");
+		assertThat(book.coverUrl()).isEqualTo("https://covers.openlibrary.org/b/id/987-L.jpg?default=false");
+		assertThat(book.readUrl()).isNull();
+		assertThat(book.formats()).isEmpty();
+		assertThat(book.imported()).isFalse();
+		assertThat(book.internalBookId()).isNull();
+		assertThat(book.sourceUrl()).isEqualTo("https://openlibrary.org/works/OL1W");
+		verifyNoInteractions(openLibraryCoverService, bookRepository);
 	}
 
 	@Test

--- a/src/test/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClientTest.java
+++ b/src/test/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClientTest.java
@@ -1,0 +1,93 @@
+package com.plumora.api.book.infrastructure.openlibrary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+class OpenLibraryClientTest {
+
+	@Test
+	void searchBooksCombinesSearchAndSubjectIntoTheQueryParam() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://openlibrary.test");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		OpenLibraryClient client = new OpenLibraryClient(builder.build());
+		String response = """
+			{
+			  "numFound": 1,
+			  "docs": [
+			    {
+			      "key": "/works/OL1W",
+			      "title": "Les Miserables",
+			      "author_name": ["Victor Hugo"],
+			      "cover_i": 987,
+			      "subject": ["Fantasy"]
+			    }
+			  ]
+			}
+			""";
+
+		server.expect(request -> assertQuery(request.getURI(), "Hugo subject:fiction"))
+			.andRespond(withSuccess(response, MediaType.APPLICATION_JSON));
+
+		OpenLibrarySearchResponse result = client.searchBooks("Hugo", "fiction", 2);
+
+		assertThat(result.numFound()).isEqualTo(1);
+		assertThat(result.docs()).hasSize(1);
+		assertThat(result.docs().getFirst().title()).isEqualTo("Les Miserables");
+		assertThat(result.docs().getFirst().coverId()).isEqualTo(987);
+		server.verify();
+	}
+
+	@Test
+	void searchBooksUsesWildcardQueryWhenNoFiltersAreProvided() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://openlibrary.test");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		OpenLibraryClient client = new OpenLibraryClient(builder.build());
+
+		server.expect(request -> assertQuery(request.getURI(), "*"))
+			.andRespond(withSuccess("{\"numFound\": 0, \"docs\": []}", MediaType.APPLICATION_JSON));
+
+		OpenLibrarySearchResponse result = client.searchBooks(null, "  ", 0);
+
+		assertThat(result.numFound()).isZero();
+		assertThat(result.docs()).isEmpty();
+		server.verify();
+	}
+
+	@Test
+	void searchBooksThrowsWhenOpenLibraryReturnsAnErrorStatus() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://openlibrary.test");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		OpenLibraryClient client = new OpenLibraryClient(builder.build());
+
+		server.expect(request -> assertQuery(request.getURI(), "*"))
+			.andRespond(withStatus(HttpStatus.FORBIDDEN));
+
+		assertThatThrownBy(() -> client.searchBooks(null, null, 1))
+			.isInstanceOf(ExternalServiceUnavailableException.class)
+			.hasMessage("Open Library is currently unavailable");
+		server.verify();
+	}
+
+	private void assertQuery(URI uri, String expectedQuery) {
+		var params = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
+		assertThat(decode(params.getFirst("q"))).isEqualTo(expectedQuery);
+		assertThat(decode(params.getFirst("fields"))).isEqualTo("key,title,author_name,cover_i,isbn,subject");
+	}
+
+	private String decode(String value) {
+		return URLDecoder.decode(value, StandardCharsets.UTF_8);
+	}
+}


### PR DESCRIPTION
## Summary
- `gutendex.com` is blocked by Cloudflare for the production VPS's IP range (`403`, managed challenge, confirmed with realistic browser headers too) - this broke book discovery ("Tendances"/"Nouveautés"/genre filters) entirely, since search, get-by-id and therefore new imports all go through that API.
- `gutenberg.org` (actual full-text hosting) is unaffected, so already-imported books remain fully readable - no change there.
- Adds `OpenLibraryClient` (new, `openlibrary.org/search.json`) and wires it as a fallback in `ExternalBookService.searchExternalBooks`: when Gutendex throws `ExternalServiceUnavailableException`, results come from Open Library instead.
- Open Library is a metadata catalog, not a full-text source like Gutendex: fallback results are mapped with `source="OPEN_LIBRARY"`, no `readUrl`/`formats`, `imported=false` - browsable, but intentionally not importable/readable in-app (Gutendex-imported books are untouched and keep working exactly as before).

## Test plan
- [x] `ExternalBookServiceTest` (10/10, including a new fallback test) and new `OpenLibraryClientTest` (3/3) pass
- [x] Full suite: 214 tests, 0 failures (5 pre-existing Testcontainers errors, unrelated - no local Docker daemon)
- [ ] After merge + deploy, confirm "Tendances"/"Nouveautés"/genre sections show real books instead of "Catalogue externe momentanément indisponible"