### PR TITLE
fix(catalog): stop sending a bare q=* to Open Library

### DIFF
--- a/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClient.java
+++ b/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClient.java
@@ -44,8 +44,14 @@ public class OpenLibraryClient {
 					uriBuilder.path("/search.json")
 						.queryParam("fields", SEARCH_FIELDS)
 						.queryParam("limit", PAGE_SIZE)
-						.queryParam("page", Math.max(page, 1))
-						.queryParam("q", query(search, subject));
+						.queryParam("page", Math.max(page, 1));
+					// Open Library rejects a bare "q=*" wildcard with 422 (confirmed against the
+					// real API): when there is no search text or subject filter, the "q" param
+					// must be omitted entirely rather than sent as a wildcard.
+					String query = query(search, subject);
+					if (StringUtils.hasText(query)) {
+						uriBuilder.queryParam("q", query);
+					}
 					return uriBuilder.build();
 				})
 				.retrieve()
@@ -71,7 +77,7 @@ public class OpenLibraryClient {
 			}
 			query.append("subject:").append(subject.trim());
 		}
-		return query.isEmpty() ? "*" : query.toString();
+		return query.isEmpty() ? null : query.toString();
 	}
 
 	private OpenLibrarySearchResponse empty() {

--- a/src/test/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClientTest.java
+++ b/src/test/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClientTest.java
@@ -51,12 +51,15 @@ class OpenLibraryClientTest {
 	}
 
 	@Test
-	void searchBooksUsesWildcardQueryWhenNoFiltersAreProvided() {
+	void searchBooksOmitsTheQueryParamWhenNoFiltersAreProvided() {
+		// Open Library rejects a bare "q=*" wildcard with 422 (confirmed against the real API):
+		// the "q" param must be entirely absent, not sent as a wildcard, when browsing without
+		// a search term or subject filter.
 		RestClient.Builder builder = RestClient.builder().baseUrl("https://openlibrary.test");
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
 		OpenLibraryClient client = new OpenLibraryClient(builder.build());
 
-		server.expect(request -> assertQuery(request.getURI(), "*"))
+		server.expect(request -> assertNoQueryParam(request.getURI()))
 			.andRespond(withSuccess("{\"numFound\": 0, \"docs\": []}", MediaType.APPLICATION_JSON));
 
 		OpenLibrarySearchResponse result = client.searchBooks(null, "  ", 0);
@@ -72,7 +75,7 @@ class OpenLibraryClientTest {
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
 		OpenLibraryClient client = new OpenLibraryClient(builder.build());
 
-		server.expect(request -> assertQuery(request.getURI(), "*"))
+		server.expect(request -> assertNoQueryParam(request.getURI()))
 			.andRespond(withStatus(HttpStatus.FORBIDDEN));
 
 		assertThatThrownBy(() -> client.searchBooks(null, null, 1))
@@ -84,6 +87,12 @@ class OpenLibraryClientTest {
 	private void assertQuery(URI uri, String expectedQuery) {
 		var params = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
 		assertThat(decode(params.getFirst("q"))).isEqualTo(expectedQuery);
+		assertThat(decode(params.getFirst("fields"))).isEqualTo("key,title,author_name,cover_i,isbn,subject");
+	}
+
+	private void assertNoQueryParam(URI uri) {
+		var params = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
+		assertThat(params.containsKey("q")).isFalse();
 		assertThat(decode(params.getFirst("fields"))).isEqualTo("key,title,author_name,cover_i,isbn,subject");
 	}
 


### PR DESCRIPTION
## Summary
- Confirmed against the real `openlibrary.org` API right after deploying #14: `q=*` returns `422 Unprocessable Entity`, which broke the Gutendex fallback for exactly the case it exists for (browsing "Tendances"/"Nouveautes" with no search term or subject filter). `q=subject:fantasy` and plain text searches work fine.
- Fix: omit the `q` param entirely instead of sending a wildcard when there's no search text or subject filter.
- Verified directly against the real API (not just mocked) before pushing this fix.

## Test plan
- [x] `OpenLibraryClientTest` (3/3) and `ExternalBookServiceTest` (10/10) pass
- [x] Manually confirmed against the real Open Library API: omitting `q` returns `200`
- [ ] After merge + deploy, confirm "Tendances"/"Nouveautes" sections load real books