### PR TITLE
fix(catalog): default Open Library query to a broad subject

### DIFF
--- a/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClient.java
+++ b/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClient.java
@@ -44,14 +44,8 @@ public class OpenLibraryClient {
 					uriBuilder.path("/search.json")
 						.queryParam("fields", SEARCH_FIELDS)
 						.queryParam("limit", PAGE_SIZE)
-						.queryParam("page", Math.max(page, 1));
-					// Open Library rejects a bare "q=*" wildcard with 422 (confirmed against the
-					// real API): when there is no search text or subject filter, the "q" param
-					// must be omitted entirely rather than sent as a wildcard.
-					String query = query(search, subject);
-					if (StringUtils.hasText(query)) {
-						uriBuilder.queryParam("q", query);
-					}
+						.queryParam("page", Math.max(page, 1))
+						.queryParam("q", query(search, subject));
 					return uriBuilder.build();
 				})
 				.retrieve()
@@ -77,7 +71,11 @@ public class OpenLibraryClient {
 			}
 			query.append("subject:").append(subject.trim());
 		}
-		return query.isEmpty() ? null : query.toString();
+		// Open Library rejects a bare "q=*" wildcard with 422, and an entirely omitted "q"
+		// returns zero results (both confirmed against the real API) - default to a broad
+		// subject so discovery sections without an explicit filter (e.g. "Tendances"/
+		// "Nouveautes") still show real, browsable books instead of an empty list.
+		return query.isEmpty() ? "subject:fiction" : query.toString();
 	}
 
 	private OpenLibrarySearchResponse empty() {

--- a/src/test/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClientTest.java
+++ b/src/test/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClientTest.java
@@ -51,15 +51,16 @@ class OpenLibraryClientTest {
 	}
 
 	@Test
-	void searchBooksOmitsTheQueryParamWhenNoFiltersAreProvided() {
-		// Open Library rejects a bare "q=*" wildcard with 422 (confirmed against the real API):
-		// the "q" param must be entirely absent, not sent as a wildcard, when browsing without
-		// a search term or subject filter.
+	void searchBooksDefaultsToABroadSubjectWhenNoFiltersAreProvided() {
+		// Open Library rejects a bare "q=*" wildcard with 422, and an entirely omitted "q"
+		// returns zero results (both confirmed against the real API): default to a broad
+		// subject instead, so browsing without a search term or subject filter still returns
+		// real, browsable books.
 		RestClient.Builder builder = RestClient.builder().baseUrl("https://openlibrary.test");
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
 		OpenLibraryClient client = new OpenLibraryClient(builder.build());
 
-		server.expect(request -> assertNoQueryParam(request.getURI()))
+		server.expect(request -> assertQuery(request.getURI(), "subject:fiction"))
 			.andRespond(withSuccess("{\"numFound\": 0, \"docs\": []}", MediaType.APPLICATION_JSON));
 
 		OpenLibrarySearchResponse result = client.searchBooks(null, "  ", 0);
@@ -75,7 +76,7 @@ class OpenLibraryClientTest {
 		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
 		OpenLibraryClient client = new OpenLibraryClient(builder.build());
 
-		server.expect(request -> assertNoQueryParam(request.getURI()))
+		server.expect(request -> assertQuery(request.getURI(), "subject:fiction"))
 			.andRespond(withStatus(HttpStatus.FORBIDDEN));
 
 		assertThatThrownBy(() -> client.searchBooks(null, null, 1))
@@ -87,12 +88,6 @@ class OpenLibraryClientTest {
 	private void assertQuery(URI uri, String expectedQuery) {
 		var params = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
 		assertThat(decode(params.getFirst("q"))).isEqualTo(expectedQuery);
-		assertThat(decode(params.getFirst("fields"))).isEqualTo("key,title,author_name,cover_i,isbn,subject");
-	}
-
-	private void assertNoQueryParam(URI uri) {
-		var params = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
-		assertThat(params.containsKey("q")).isFalse();
 		assertThat(decode(params.getFirst("fields"))).isEqualTo("key,title,author_name,cover_i,isbn,subject");
 	}
 


### PR DESCRIPTION
## Summary
- Follow-up to #15: omitting the "q" param entirely (the fix for the 422 on `q=*`) turned out to return zero results rather than a general listing - confirmed against the real API right after deploying it. "Tendances"/"Nouveautes" (no search term or subject filter) loaded without error but stayed empty.
- Now defaults to `q=subject:fiction` when there's no search text or subject filter, which returns real, browsable results (verified directly against the real Open Library API: `numFound: 1678217`).

## Test plan
- [x] `OpenLibraryClientTest` (3/3) and `ExternalBookServiceTest` (10/10) pass
- [x] Manually confirmed against the real Open Library API before pushing
- [ ] After merge + deploy, confirm "Tendances"/"Nouveautes" show real books, not an empty list