### PR TITLE
fix(catalog): raise Open Library read timeout to 10s

### DIFF
--- a/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClient.java
+++ b/src/main/java/com/plumora/api/book/infrastructure/openlibrary/OpenLibraryClient.java
@@ -85,7 +85,10 @@ public class OpenLibraryClient {
 	private static RestClient createRestClient(String baseUrl) {
 		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
 		requestFactory.setConnectTimeout(3000);
-		requestFactory.setReadTimeout(5000);
+		// The default (no search/subject) fallback query matches millions of documents, which
+		// is measurably slower for Open Library to paginate than a narrow subject query - 5s
+		// was intermittently too tight for it in production, causing spurious 503s.
+		requestFactory.setReadTimeout(10000);
 		return RestClient.builder()
 			.baseUrl(baseUrl)
 			.requestFactory(requestFactory)


### PR DESCRIPTION
## Summary
- The default (unfiltered) fallback query (`subject:fiction`, added in #16) matches ~1.7M documents - measurably slower for Open Library to paginate than a narrow query like `subject:fantasy`.
- Observed live in production after deploying #16: "Tendances"/"Nouveautes" intermittently returned `503` even though the exact same request succeeded (slowly) moments later on retry - classic symptom of a too-tight client timeout, not an actual outage.
- Raises `readTimeout` from 5s to 10s, matching `GutendexContentClient`'s existing 10s timeout for similarly slow external calls.

## Test plan
- [x] `OpenLibraryClientTest` (3/3) passes