### PR TITLE
feat(catalog): local Gutenberg catalog for real search and reading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
 			<artifactId>jjwt-api</artifactId>
 			<version>0.12.6</version>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-csv</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/plumora/api/PlumoraApiApplication.java
+++ b/src/main/java/com/plumora/api/PlumoraApiApplication.java
@@ -2,8 +2,12 @@ package com.plumora.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableAsync
+@EnableScheduling
 public class PlumoraApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/plumora/api/book/application/ExternalBookService.java
+++ b/src/main/java/com/plumora/api/book/application/ExternalBookService.java
@@ -5,8 +5,10 @@ import com.plumora.api.book.domain.BookStatus;
 import com.plumora.api.book.domain.BookVisibility;
 import com.plumora.api.book.domain.Chapter;
 import com.plumora.api.book.domain.ExternalBookSource;
+import com.plumora.api.book.domain.GutenbergCatalogEntry;
 import com.plumora.api.book.infrastructure.BookRepository;
 import com.plumora.api.book.infrastructure.ChapterRepository;
+import com.plumora.api.book.infrastructure.GutenbergCatalogEntryRepository;
 import com.plumora.api.book.infrastructure.gutendex.GutendexContentClient;
 import com.plumora.api.book.infrastructure.gutendex.GutendexAuthorResponse;
 import com.plumora.api.book.infrastructure.gutendex.GutendexBookResponse;
@@ -57,6 +59,7 @@ public class ExternalBookService {
 	private final GutendexClient gutendexClient;
 	private final GutendexContentClient gutendexContentClient;
 	private final ExternalBookContentSanitizer externalBookContentSanitizer;
+	private final GutenbergCatalogEntryRepository gutenbergCatalogEntryRepository;
 	private final OpenLibraryClient openLibraryClient;
 	private final OpenLibraryCoverService openLibraryCoverService;
 	private final BookRepository bookRepository;
@@ -67,6 +70,7 @@ public class ExternalBookService {
 		GutendexClient gutendexClient,
 		GutendexContentClient gutendexContentClient,
 		ExternalBookContentSanitizer externalBookContentSanitizer,
+		GutenbergCatalogEntryRepository gutenbergCatalogEntryRepository,
 		OpenLibraryClient openLibraryClient,
 		OpenLibraryCoverService openLibraryCoverService,
 		BookRepository bookRepository,
@@ -76,6 +80,7 @@ public class ExternalBookService {
 		this.gutendexClient = gutendexClient;
 		this.gutendexContentClient = gutendexContentClient;
 		this.externalBookContentSanitizer = externalBookContentSanitizer;
+		this.gutenbergCatalogEntryRepository = gutenbergCatalogEntryRepository;
 		this.openLibraryClient = openLibraryClient;
 		this.openLibraryCoverService = openLibraryCoverService;
 		this.bookRepository = bookRepository;
@@ -86,6 +91,15 @@ public class ExternalBookService {
 	@Transactional(readOnly = true)
 	public Page<ExternalBook> searchExternalBooks(String search, String language, String topic, int page) {
 		int safePage = Math.max(page, 0);
+		// Local Gutenberg catalog first: a plain DB query against our own mirror of Project
+		// Gutenberg's official catalog (see GutenbergCatalogSyncService), never gutendex.com
+		// (blocked by Cloudflare from the production VPS - confirmed even from GitHub Actions
+		// runners, so it isn't an IP-reputation quirk specific to this VPS). Results from here
+		// are genuinely readable: reading downloads straight from gutenberg.org.
+		Page<ExternalBook> localResults = searchLocalGutenbergCatalog(search, topic, safePage);
+		if (localResults.hasContent()) {
+			return localResults;
+		}
 		try {
 			GutendexSearchRequest request = GutendexSearchRequest.publicDomain(
 				normalize(search),
@@ -100,12 +114,26 @@ public class ExternalBookService {
 			long total = Math.max(response.count(), books.size());
 			return new PageImpl<>(books, PageRequest.of(safePage, GUTENDEX_PAGE_SIZE), total);
 		} catch (ExternalServiceUnavailableException exception) {
-			// Gutendex (gutendex.com) is unreachable - fall back to Open Library for discovery.
-			// Open Library is a metadata catalog, not a full-text source: results mapped from it
-			// never carry a readUrl/formats, so the app must not offer to import/read them, only
-			// browse (see toExternalBook(OpenLibraryDocResponse)).
+			// Gutendex is unreachable and the local catalog had no match either - fall back to
+			// Open Library for discovery. Open Library is a metadata catalog, not a full-text
+			// source: results mapped from it never carry a readUrl/formats, so the app must not
+			// offer to import/read them, only browse (see toExternalBook(OpenLibraryDocResponse)).
 			return searchOpenLibraryBooks(normalize(search), normalize(topic), safePage);
 		}
+	}
+
+	private Page<ExternalBook> searchLocalGutenbergCatalog(String search, String topic, int safePage) {
+		Page<GutenbergCatalogEntry> entries = gutenbergCatalogEntryRepository.search(
+			likePattern(search),
+			likePattern(topic),
+			PageRequest.of(safePage, GUTENDEX_PAGE_SIZE)
+		);
+		return entries.map(this::toExternalBook);
+	}
+
+	private String likePattern(String value) {
+		String normalized = normalize(value);
+		return normalized == null ? null : "%" + normalized.toLowerCase(Locale.ROOT) + "%";
 	}
 
 	private Page<ExternalBook> searchOpenLibraryBooks(String search, String topic, int safePage) {
@@ -124,6 +152,10 @@ public class ExternalBookService {
 
 	@Transactional(readOnly = true)
 	public ExternalBook getExternalBook(int gutendexId) {
+		Optional<GutenbergCatalogEntry> localEntry = gutenbergCatalogEntryRepository.findById(gutendexId);
+		if (localEntry.isPresent()) {
+			return toExternalBook(localEntry.get());
+		}
 		return gutendexClient.getBook(gutendexId)
 			.map(this::toExternalBook)
 			.orElseThrow(() -> new ResourceNotFoundException("External book was not found"));
@@ -203,6 +235,40 @@ public class ExternalBookService {
 			importedBookId.isPresent(),
 			importedBookId.orElse(null)
 		);
+	}
+
+	private ExternalBook toExternalBook(GutenbergCatalogEntry entry) {
+		Map<String, String> formats = Map.of("text/plain; charset=utf-8", entry.getContentUrl());
+		Optional<java.util.UUID> importedBookId = importedBookId(entry.getGutenbergId());
+
+		return new ExternalBook(
+			String.valueOf(entry.getGutenbergId()),
+			ExternalBookSource.GUTENDEX.name(),
+			entry.getTitle(),
+			splitSemicolonList(entry.getAuthors()),
+			null,
+			splitSemicolonList(entry.getSubjects()),
+			List.of(entry.getLanguageCode()),
+			null,
+			"text/plain",
+			0,
+			entry.getCoverUrl(),
+			entry.getContentUrl(),
+			formats,
+			GUTENBERG_SOURCE_URL + entry.getGutenbergId(),
+			importedBookId.isPresent(),
+			importedBookId.orElse(null)
+		);
+	}
+
+	private List<String> splitSemicolonList(String value) {
+		if (!StringUtils.hasText(value)) {
+			return List.of();
+		}
+		return java.util.Arrays.stream(value.split(";"))
+			.map(String::trim)
+			.filter(StringUtils::hasText)
+			.toList();
 	}
 
 	private ExternalBook toExternalBook(OpenLibraryDocResponse doc) {

--- a/src/main/java/com/plumora/api/book/application/GutenbergCatalogSyncService.java
+++ b/src/main/java/com/plumora/api/book/application/GutenbergCatalogSyncService.java
@@ -1,0 +1,178 @@
+package com.plumora.api.book.application;
+
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.plumora.api.book.infrastructure.GutenbergCatalogEntryRepository;
+import com.plumora.api.book.infrastructure.gutenberg.GutenbergCatalogClient;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Keeps a local mirror of Project Gutenberg's own official catalog (see
+ * GutenbergCatalogClient), so book discovery/search and reading work entirely off our own
+ * database and gutenberg.org content URLs, with no live call to gutendex.com (blocked by
+ * Cloudflare from the production VPS).
+ *
+ * <p>The upsert writes go through JdbcTemplate batches rather than the JPA repository/entity
+ * lifecycle: tens of thousands of rows per sync would otherwise bloat the persistence context
+ * for a background job whose only real requirement is "get the rows into the table".
+ */
+@Service
+public class GutenbergCatalogSyncService {
+
+	private static final Logger log = LoggerFactory.getLogger(GutenbergCatalogSyncService.class);
+	private static final int BATCH_SIZE = 1000;
+	private static final String UPSERT_SQL = """
+		insert into gutenberg_catalog_entries
+			(gutenberg_id, title, authors, language_code, subjects, bookshelves, issued_date, cover_url, content_url, synced_at)
+		values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		on conflict (gutenberg_id) do update set
+			title = excluded.title,
+			authors = excluded.authors,
+			language_code = excluded.language_code,
+			subjects = excluded.subjects,
+			bookshelves = excluded.bookshelves,
+			issued_date = excluded.issued_date,
+			cover_url = excluded.cover_url,
+			content_url = excluded.content_url,
+			synced_at = excluded.synced_at
+		""";
+
+	private final GutenbergCatalogClient gutenbergCatalogClient;
+	private final GutenbergCatalogEntryRepository gutenbergCatalogEntryRepository;
+	private final JdbcTemplate jdbcTemplate;
+	private final CsvMapper csvMapper = new CsvMapper();
+
+	public GutenbergCatalogSyncService(
+		GutenbergCatalogClient gutenbergCatalogClient,
+		GutenbergCatalogEntryRepository gutenbergCatalogEntryRepository,
+		JdbcTemplate jdbcTemplate
+	) {
+		this.gutenbergCatalogClient = gutenbergCatalogClient;
+		this.gutenbergCatalogEntryRepository = gutenbergCatalogEntryRepository;
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void syncOnStartupIfEmpty() {
+		if (gutenbergCatalogEntryRepository.count() == 0) {
+			log.info("Gutenberg catalog is empty - triggering an initial sync in the background.");
+			syncCatalog();
+		}
+	}
+
+	@Async
+	@Scheduled(cron = "0 0 4 * * *")
+	public void syncCatalog() {
+		try {
+			String csv = gutenbergCatalogClient.downloadCatalogCsv();
+			int imported = parseAndUpsert(csv);
+			log.info("Gutenberg catalog sync complete: {} entries upserted.", imported);
+		} catch (Exception exception) {
+			log.warn("Gutenberg catalog sync failed, keeping the existing data as-is.", exception);
+		}
+	}
+
+	private int parseAndUpsert(String csv) throws java.io.IOException {
+		CsvSchema schema = CsvSchema.emptySchema().withHeader();
+		com.fasterxml.jackson.databind.MappingIterator<Map<String, String>> rows = csvMapper
+			.readerFor(Map.class)
+			.with(schema)
+			.readValues(csv);
+
+		List<Object[]> batch = new ArrayList<>(BATCH_SIZE);
+		int total = 0;
+		Timestamp now = Timestamp.valueOf(LocalDateTime.now());
+		while (rows.hasNext()) {
+			Object[] params = toRow(rows.next(), now);
+			if (params != null) {
+				batch.add(params);
+			}
+			if (batch.size() >= BATCH_SIZE) {
+				jdbcTemplate.batchUpdate(UPSERT_SQL, batch);
+				total += batch.size();
+				batch.clear();
+			}
+		}
+		if (!batch.isEmpty()) {
+			jdbcTemplate.batchUpdate(UPSERT_SQL, batch);
+			total += batch.size();
+		}
+		return total;
+	}
+
+	private Object[] toRow(Map<String, String> row, Timestamp now) {
+		if (!"Text".equals(row.get("Type")) || !"en".equals(row.get("Language"))) {
+			return null;
+		}
+		Integer gutenbergId = parseId(row.get("Text#"));
+		String title = normalizeTitle(row.get("Title"));
+		if (gutenbergId == null || !StringUtils.hasText(title)) {
+			return null;
+		}
+		return new Object[] {
+			gutenbergId,
+			limit(title, 500),
+			limit(row.get("Authors"), 500),
+			"en",
+			row.get("Subjects"),
+			row.get("Bookshelves"),
+			parseIssuedDate(row.get("Issued")),
+			"https://www.gutenberg.org/cache/epub/" + gutenbergId + "/pg" + gutenbergId + ".cover.medium.jpg",
+			"https://www.gutenberg.org/files/" + gutenbergId + "/" + gutenbergId + "-0.txt",
+			now
+		};
+	}
+
+	private Integer parseId(String value) {
+		if (!StringUtils.hasText(value)) {
+			return null;
+		}
+		try {
+			return Integer.valueOf(value.trim());
+		} catch (NumberFormatException exception) {
+			return null;
+		}
+	}
+
+	private String normalizeTitle(String title) {
+		if (!StringUtils.hasText(title)) {
+			return null;
+		}
+		return title.replace('\n', ' ').replace('\r', ' ').trim();
+	}
+
+	private Date parseIssuedDate(String value) {
+		if (!StringUtils.hasText(value)) {
+			return null;
+		}
+		try {
+			return Date.valueOf(LocalDate.parse(value.trim()));
+		} catch (DateTimeParseException exception) {
+			return null;
+		}
+	}
+
+	private String limit(String value, int maxLength) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.length() <= maxLength ? trimmed : trimmed.substring(0, maxLength);
+	}
+}

--- a/src/main/java/com/plumora/api/book/domain/GutenbergCatalogEntry.java
+++ b/src/main/java/com/plumora/api/book/domain/GutenbergCatalogEntry.java
@@ -1,0 +1,55 @@
+package com.plumora.api.book.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * A local mirror of one entry from Project Gutenberg's own official catalog CSV, downloaded
+ * directly from gutenberg.org (see GutenbergCatalogSyncService). Never populated from
+ * gutendex.com, which is blocked by Cloudflare from the production VPS.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "gutenberg_catalog_entries")
+public class GutenbergCatalogEntry {
+
+	@Id
+	@Column(name = "gutenberg_id")
+	private Integer gutenbergId;
+
+	@Column(name = "title", nullable = false, length = 500)
+	private String title;
+
+	@Column(name = "authors", length = 500)
+	private String authors;
+
+	@Column(name = "language_code", nullable = false, length = 10)
+	private String languageCode;
+
+	@Column(name = "subjects")
+	private String subjects;
+
+	@Column(name = "bookshelves")
+	private String bookshelves;
+
+	@Column(name = "issued_date")
+	private LocalDate issuedDate;
+
+	@Column(name = "cover_url", length = 500)
+	private String coverUrl;
+
+	@Column(name = "content_url", nullable = false, length = 500)
+	private String contentUrl;
+
+	@Column(name = "synced_at", nullable = false)
+	private LocalDateTime syncedAt;
+}

--- a/src/main/java/com/plumora/api/book/infrastructure/GutenbergCatalogEntryRepository.java
+++ b/src/main/java/com/plumora/api/book/infrastructure/GutenbergCatalogEntryRepository.java
@@ -1,0 +1,31 @@
+package com.plumora.api.book.infrastructure;
+
+import com.plumora.api.book.domain.GutenbergCatalogEntry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface GutenbergCatalogEntryRepository extends JpaRepository<GutenbergCatalogEntry, Integer> {
+
+	// :query and :subject are expected to already be lowercased "%...%" LIKE patterns built by
+	// the caller (see ExternalBookService), matching the convention used by BookRepository.
+	@Query("""
+		select e from GutenbergCatalogEntry e
+		where (:subject is null
+			or lower(coalesce(e.bookshelves, '')) like :subject
+			or lower(coalesce(e.subjects, '')) like :subject
+		)
+		and (:query is null
+			or lower(e.title) like :query
+			or lower(coalesce(e.authors, '')) like :query
+		)
+		order by e.issuedDate desc nulls last, e.title asc
+		""")
+	Page<GutenbergCatalogEntry> search(
+		@Param("query") String query,
+		@Param("subject") String subject,
+		Pageable pageable
+	);
+}

--- a/src/main/java/com/plumora/api/book/infrastructure/gutenberg/GutenbergCatalogClient.java
+++ b/src/main/java/com/plumora/api/book/infrastructure/gutenberg/GutenbergCatalogClient.java
@@ -1,0 +1,72 @@
+package com.plumora.api.book.infrastructure.gutenberg;
+
+import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * Downloads Project Gutenberg's own official catalog CSV directly from gutenberg.org - never
+ * from gutendex.com, which is blocked by Cloudflare from the production VPS (confirmed: 403
+ * with a managed challenge page, even from GitHub Actions runners, so it isn't specific to the
+ * VPS's own IP). gutenberg.org itself is unaffected. See GutenbergCatalogSyncService for how
+ * this feeds the local catalog used for discovery and reading.
+ */
+@Component
+public class GutenbergCatalogClient {
+
+	private static final Logger log = LoggerFactory.getLogger(GutenbergCatalogClient.class);
+
+	private final RestClient restClient;
+
+	@Autowired
+	public GutenbergCatalogClient(
+		@Value("${app.external.gutenberg.catalog-url:https://www.gutenberg.org/cache/epub/feeds/pg_catalog.csv}") String catalogUrl
+	) {
+		this(createRestClient(catalogUrl));
+	}
+
+	GutenbergCatalogClient(RestClient restClient) {
+		this.restClient = restClient;
+	}
+
+	public String downloadCatalogCsv() {
+		try {
+			String body = restClient.get().retrieve().body(String.class);
+			if (!StringUtils.hasText(body)) {
+				throw unavailable("Gutenberg catalog download returned an empty body", null);
+			}
+			return body;
+		} catch (RestClientResponseException exception) {
+			throw unavailable("Gutenberg catalog download failed with status " + exception.getStatusCode().value(), exception);
+		} catch (ResourceAccessException exception) {
+			throw unavailable("Gutenberg catalog download timed out or could not be reached", exception);
+		} catch (RestClientException exception) {
+			throw unavailable("Gutenberg catalog download failed", exception);
+		}
+	}
+
+	private static RestClient createRestClient(String catalogUrl) {
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(10_000);
+		// The catalog CSV is ~21MB - a plain search/content timeout would be far too tight.
+		requestFactory.setReadTimeout(120_000);
+		return RestClient.builder()
+			.baseUrl(catalogUrl)
+			.requestFactory(requestFactory)
+			.build();
+	}
+
+	private ExternalServiceUnavailableException unavailable(String message, Exception exception) {
+		log.warn(message, exception);
+		return new ExternalServiceUnavailableException("Gutenberg catalog is currently unavailable");
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,8 @@ app:
   external:
     gutendex:
       base-url: ${GUTENDEX_BASE_URL:https://gutendex.com}
+    gutenberg:
+      catalog-url: ${GUTENBERG_CATALOG_URL:https://www.gutenberg.org/cache/epub/feeds/pg_catalog.csv}
     open-library:
       base-url: ${OPEN_LIBRARY_BASE_URL:https://openlibrary.org}
     gemini:

--- a/src/main/resources/db/migration/V20__create_gutenberg_catalog_entries.sql
+++ b/src/main/resources/db/migration/V20__create_gutenberg_catalog_entries.sql
@@ -1,0 +1,21 @@
+-- Local mirror of Project Gutenberg's own official catalog (downloaded directly from
+-- gutenberg.org, never from gutendex.com - see GutenbergCatalogSyncService). Lets book
+-- discovery/search work entirely against our own database, and lets reading construct
+-- gutenberg.org content URLs directly, without any live call to the third-party gutendex.com
+-- API that is blocked by Cloudflare from the production VPS.
+CREATE TABLE gutenberg_catalog_entries (
+    gutenberg_id INTEGER PRIMARY KEY,
+    title VARCHAR(500) NOT NULL,
+    authors VARCHAR(500),
+    language_code VARCHAR(10) NOT NULL,
+    subjects TEXT,
+    bookshelves TEXT,
+    issued_date DATE,
+    cover_url VARCHAR(500),
+    content_url VARCHAR(500) NOT NULL,
+    synced_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_gutenberg_catalog_entries_language_code ON gutenberg_catalog_entries(language_code);
+CREATE INDEX idx_gutenberg_catalog_entries_title_lower ON gutenberg_catalog_entries(lower(title));
+CREATE INDEX idx_gutenberg_catalog_entries_bookshelves_lower ON gutenberg_catalog_entries(lower(bookshelves));

--- a/src/test/java/com/plumora/api/book/application/ExternalBookServiceTest.java
+++ b/src/test/java/com/plumora/api/book/application/ExternalBookServiceTest.java
@@ -3,6 +3,8 @@ package com.plumora.api.book.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -13,8 +15,10 @@ import com.plumora.api.book.domain.BookStatus;
 import com.plumora.api.book.domain.BookVisibility;
 import com.plumora.api.book.domain.Chapter;
 import com.plumora.api.book.domain.ExternalBookSource;
+import com.plumora.api.book.domain.GutenbergCatalogEntry;
 import com.plumora.api.book.infrastructure.BookRepository;
 import com.plumora.api.book.infrastructure.ChapterRepository;
+import com.plumora.api.book.infrastructure.GutenbergCatalogEntryRepository;
 import com.plumora.api.book.infrastructure.gutendex.GutendexAuthorResponse;
 import com.plumora.api.book.infrastructure.gutendex.GutendexBookResponse;
 import com.plumora.api.book.infrastructure.gutendex.GutendexClient;
@@ -29,6 +33,8 @@ import com.plumora.api.shared.exception.BusinessException;
 import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
 import com.plumora.api.user.application.UserService;
 import com.plumora.api.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +46,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class ExternalBookServiceTest {
@@ -52,6 +62,9 @@ class ExternalBookServiceTest {
 
 	@Mock
 	private ExternalBookContentSanitizer externalBookContentSanitizer;
+
+	@Mock
+	private GutenbergCatalogEntryRepository gutenbergCatalogEntryRepository;
 
 	@Mock
 	private OpenLibraryClient openLibraryClient;
@@ -76,12 +89,19 @@ class ExternalBookServiceTest {
 			gutendexClient,
 			gutendexContentClient,
 			externalBookContentSanitizer,
+			gutenbergCatalogEntryRepository,
 			openLibraryClient,
 			openLibraryCoverService,
 			bookRepository,
 			chapterRepository,
 			userService
 		);
+		// Empty by default so every existing Gutendex/Open Library test keeps working unchanged;
+		// tests that care about the local catalog override this explicitly. lenient() because
+		// tests that never reach searchExternalBooks/getExternalBook don't need this stub.
+		lenient().when(gutenbergCatalogEntryRepository.search(any(), any(), any(Pageable.class)))
+			.thenReturn(Page.empty());
+		lenient().when(gutenbergCatalogEntryRepository.findById(anyInt())).thenReturn(Optional.empty());
 	}
 
 	@Test
@@ -153,6 +173,58 @@ class ExternalBookServiceTest {
 
 		assertThat(book.imported()).isTrue();
 		assertThat(book.internalBookId()).isEqualTo(importedBook.getId());
+	}
+
+	@Test
+	void searchExternalBooksUsesTheLocalGutenbergCatalogBeforeGutendexOrOpenLibrary() {
+		GutenbergCatalogEntry entry = gutenbergCatalogEntry();
+		when(gutenbergCatalogEntryRepository.search(any(), any(), any(Pageable.class)))
+			.thenReturn(new PageImpl<>(List.of(entry), PageRequest.of(0, 32), 1));
+
+		var page = externalBookService.searchExternalBooks("Hugo", "fr", "fiction", 0);
+
+		ExternalBook book = page.getContent().getFirst();
+		assertThat(book.externalId()).isEqualTo("123");
+		assertThat(book.source()).isEqualTo("GUTENDEX");
+		assertThat(book.title()).isEqualTo("Les Miserables");
+		assertThat(book.authors()).containsExactly("Hugo, Victor, 1802-1885");
+		assertThat(book.subjects()).containsExactly("French fiction", "Classics");
+		assertThat(book.languages()).containsExactly("en");
+		assertThat(book.coverUrl()).isEqualTo("https://www.gutenberg.org/cache/epub/123/pg123.cover.medium.jpg");
+		assertThat(book.readUrl()).isEqualTo("https://www.gutenberg.org/files/123/123-0.txt");
+		assertThat(book.formats()).containsEntry("text/plain; charset=utf-8", "https://www.gutenberg.org/files/123/123-0.txt");
+		assertThat(book.imported()).isFalse();
+		verifyNoInteractions(gutendexClient, openLibraryClient);
+	}
+
+	@Test
+	void getExternalBookUsesTheLocalGutenbergCatalogEntryBeforeCallingGutendexLive() {
+		when(gutenbergCatalogEntryRepository.findById(123)).thenReturn(Optional.of(gutenbergCatalogEntry()));
+
+		ExternalBook book = externalBookService.getExternalBook(123);
+
+		assertThat(book.title()).isEqualTo("Les Miserables");
+		assertThat(book.readUrl()).isEqualTo("https://www.gutenberg.org/files/123/123-0.txt");
+		verifyNoInteractions(gutendexClient);
+	}
+
+	@Test
+	void importGutendexBookReadsContentFromTheLocalGutenbergCatalogEntryUrl() {
+		User admin = user("admin@example.com");
+		when(bookRepository.findByExternalSourceAndExternalId(ExternalBookSource.GUTENDEX, "123"))
+			.thenReturn(Optional.empty());
+		when(userService.getCurrentUser(admin.getEmail())).thenReturn(admin);
+		when(gutenbergCatalogEntryRepository.findById(123)).thenReturn(Optional.of(gutenbergCatalogEntry()));
+		when(gutendexContentClient.download("https://www.gutenberg.org/files/123/123-0.txt")).thenReturn("RAW TEXT");
+		when(externalBookContentSanitizer.sanitize("RAW TEXT", "text/plain; charset=utf-8")).thenReturn("Clean text");
+		when(bookRepository.save(any(Book.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(chapterRepository.save(any(Chapter.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		ImportedExternalBookResult result = externalBookService.importGutendexBook(admin.getEmail(), 123);
+
+		assertThat(result.created()).isTrue();
+		assertThat(result.book().getReadUrl()).isEqualTo("https://www.gutenberg.org/files/123/123-0.txt");
+		verifyNoInteractions(gutendexClient);
 	}
 
 	@Test
@@ -317,6 +389,21 @@ class ExternalBookServiceTest {
 			.hasMessage("No readable Gutendex content format is available");
 		verify(bookRepository, never()).save(any(Book.class));
 		verifyNoInteractions(gutendexContentClient, externalBookContentSanitizer);
+	}
+
+	private GutenbergCatalogEntry gutenbergCatalogEntry() {
+		GutenbergCatalogEntry entry = new GutenbergCatalogEntry();
+		entry.setGutenbergId(123);
+		entry.setTitle("Les Miserables");
+		entry.setAuthors("Hugo, Victor, 1802-1885");
+		entry.setLanguageCode("en");
+		entry.setSubjects("French fiction; Classics");
+		entry.setBookshelves("Classics");
+		entry.setIssuedDate(LocalDate.of(1998, 6, 1));
+		entry.setCoverUrl("https://www.gutenberg.org/cache/epub/123/pg123.cover.medium.jpg");
+		entry.setContentUrl("https://www.gutenberg.org/files/123/123-0.txt");
+		entry.setSyncedAt(LocalDateTime.now());
+		return entry;
 	}
 
 	private GutendexBookResponse gutendexBook(Map<String, String> formats) {

--- a/src/test/java/com/plumora/api/book/application/GutenbergCatalogSyncServiceTest.java
+++ b/src/test/java/com/plumora/api/book/application/GutenbergCatalogSyncServiceTest.java
@@ -1,0 +1,125 @@
+package com.plumora.api.book.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.plumora.api.book.infrastructure.GutenbergCatalogEntryRepository;
+import com.plumora.api.book.infrastructure.gutenberg.GutenbergCatalogClient;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class GutenbergCatalogSyncServiceTest {
+
+	private static final String HEADER = "Text#,Type,Issued,Title,Language,Authors,Subjects,LoCC,Bookshelves\n";
+
+	@Mock
+	private GutenbergCatalogClient gutenbergCatalogClient;
+
+	@Mock
+	private GutenbergCatalogEntryRepository gutenbergCatalogEntryRepository;
+
+	@Mock
+	private JdbcTemplate jdbcTemplate;
+
+	private GutenbergCatalogSyncService syncService;
+
+	@BeforeEach
+	void setUp() {
+		syncService = new GutenbergCatalogSyncService(gutenbergCatalogClient, gutenbergCatalogEntryRepository, jdbcTemplate);
+	}
+
+	@Test
+	void syncCatalogUpsertsOnlyEnglishTextEntriesWithComputedGutenbergUrls() {
+		String csv = HEADER
+			+ "123,Text,1998-06-01,Les Miserables,en,\"Hugo, Victor, 1802-1885\",\"French fiction; Classics\",PQ,Classics\n"
+			+ "456,Text,2001-01-01,Un Livre Francais,fr,Auteur,Sujet,PQ,Etagere\n"
+			+ "789,Audio,2010-01-01,An Audiobook,en,Someone,Sound,PQ,Audio\n";
+		when(gutenbergCatalogClient.downloadCatalogCsv()).thenReturn(csv);
+
+		syncService.syncCatalog();
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<Object[]>> batchCaptor = ArgumentCaptor.forClass(List.class);
+		verify(jdbcTemplate).batchUpdate(any(String.class), batchCaptor.capture());
+		List<Object[]> batch = batchCaptor.getValue();
+
+		assertThat(batch).hasSize(1);
+		Object[] row = batch.getFirst();
+		assertThat(row[0]).isEqualTo(123);
+		assertThat(row[1]).isEqualTo("Les Miserables");
+		assertThat(row[2]).isEqualTo("Hugo, Victor, 1802-1885");
+		assertThat(row[3]).isEqualTo("en");
+		assertThat(row[4]).isEqualTo("French fiction; Classics");
+		assertThat(row[5]).isEqualTo("Classics");
+		assertThat(row[6]).isEqualTo(Date.valueOf(LocalDate.of(1998, 6, 1)));
+		assertThat(row[7]).isEqualTo("https://www.gutenberg.org/cache/epub/123/pg123.cover.medium.jpg");
+		assertThat(row[8]).isEqualTo("https://www.gutenberg.org/files/123/123-0.txt");
+	}
+
+	@Test
+	void syncCatalogSkipsRowsWithoutAParsableIdOrTitle() {
+		String csv = HEADER
+			+ ",Text,1998-06-01,No Id,en,Author,Subject,PQ,Shelf\n"
+			+ "42,Text,1998-06-01,,en,Author,Subject,PQ,Shelf\n";
+		when(gutenbergCatalogClient.downloadCatalogCsv()).thenReturn(csv);
+
+		syncService.syncCatalog();
+
+		verify(jdbcTemplate, never()).batchUpdate(any(String.class), any(List.class));
+	}
+
+	@Test
+	void syncCatalogToleratesAMissingOrUnparsableIssuedDate() {
+		String csv = HEADER + "123,Text,,Les Miserables,en,Hugo,Subject,PQ,Shelf\n";
+		when(gutenbergCatalogClient.downloadCatalogCsv()).thenReturn(csv);
+
+		syncService.syncCatalog();
+
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<List<Object[]>> batchCaptor = ArgumentCaptor.forClass(List.class);
+		verify(jdbcTemplate).batchUpdate(any(String.class), batchCaptor.capture());
+		assertThat(batchCaptor.getValue().getFirst()[6]).isNull();
+	}
+
+	@Test
+	void syncCatalogSwallowsFailuresFromTheDownloadClient() {
+		when(gutenbergCatalogClient.downloadCatalogCsv())
+			.thenThrow(new com.plumora.api.shared.exception.ExternalServiceUnavailableException("Gutenberg catalog is currently unavailable"));
+
+		syncService.syncCatalog();
+
+		verify(jdbcTemplate, never()).batchUpdate(any(String.class), any(List.class));
+	}
+
+	@Test
+	void syncOnStartupIfEmptyTriggersSyncOnlyWhenTheLocalCatalogIsEmpty() {
+		when(gutenbergCatalogEntryRepository.count()).thenReturn(0L);
+		when(gutenbergCatalogClient.downloadCatalogCsv()).thenReturn(HEADER);
+
+		syncService.syncOnStartupIfEmpty();
+
+		verify(gutenbergCatalogClient, times(1)).downloadCatalogCsv();
+	}
+
+	@Test
+	void syncOnStartupIfEmptyDoesNothingWhenTheLocalCatalogAlreadyHasEntries() {
+		when(gutenbergCatalogEntryRepository.count()).thenReturn(50_000L);
+
+		syncService.syncOnStartupIfEmpty();
+
+		verify(gutenbergCatalogClient, never()).downloadCatalogCsv();
+	}
+}

--- a/src/test/java/com/plumora/api/book/infrastructure/gutenberg/GutenbergCatalogClientTest.java
+++ b/src/test/java/com/plumora/api/book/infrastructure/gutenberg/GutenbergCatalogClientTest.java
@@ -1,0 +1,45 @@
+package com.plumora.api.book.infrastructure.gutenberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class GutenbergCatalogClientTest {
+
+	@Test
+	void downloadCatalogCsvReturnsTheResponseBody() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://gutenberg.test/pg_catalog.csv");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		GutenbergCatalogClient client = new GutenbergCatalogClient(builder.build());
+		String csv = "Text#,Type,Issued,Title,Language,Authors,Subjects,LoCC,Bookshelves\n1,Text,1971-12-01,A Book,en,An Author,A Subject,E1,A Shelf\n";
+
+		server.expect(request -> assertThat(request.getURI().toString()).isEqualTo("https://gutenberg.test/pg_catalog.csv"))
+			.andRespond(withSuccess(csv, MediaType.parseMediaType("text/csv")));
+
+		assertThat(client.downloadCatalogCsv()).isEqualTo(csv);
+		server.verify();
+	}
+
+	@Test
+	void downloadCatalogCsvThrowsWhenGutenbergReturnsAnErrorStatus() {
+		RestClient.Builder builder = RestClient.builder().baseUrl("https://gutenberg.test/pg_catalog.csv");
+		MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+		GutenbergCatalogClient client = new GutenbergCatalogClient(builder.build());
+
+		server.expect(request -> {})
+			.andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE));
+
+		assertThatThrownBy(client::downloadCatalogCsv)
+			.isInstanceOf(ExternalServiceUnavailableException.class)
+			.hasMessage("Gutenberg catalog is currently unavailable");
+		server.verify();
+	}
+}

--- a/src/test/java/com/plumora/api/shared/config/FlywayMigrationIntegrationTest.java
+++ b/src/test/java/com/plumora/api/shared/config/FlywayMigrationIntegrationTest.java
@@ -18,7 +18,7 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * Boots the full Spring context against a real, disposable PostgreSQL container so Flyway
- * actually runs (not just parses) the 19 migrations, in order, and so ddl-auto=validate confirms
+ * actually runs (not just parses) the 20 migrations, in order, and so ddl-auto=validate confirms
  * the JPA entities agree with the resulting schema. None of the other tests in this suite exercise
  * a real database - they mock the repository layer - so this is the one test that would catch a
  * broken or out-of-order migration before it reaches a real environment.
@@ -50,7 +50,7 @@ class FlywayMigrationIntegrationTest {
 			Integer.class
 		);
 
-		assertThat(appliedCount).isEqualTo(19);
+		assertThat(appliedCount).isEqualTo(20);
 		assertThat(failedCount).isZero();
 	}
 


### PR DESCRIPTION
## Summary
- `gutendex.com` (search AND get-by-id) is blocked by Cloudflare from the production VPS - confirmed even from GitHub Actions runners, so it's not an IP-reputation quirk specific to this VPS. The Open Library fallback (#14-#17) restored browsing, but Open Library has no full-text content, so nothing new could actually be **read**.
- `gutenberg.org` itself (Project Gutenberg's own site, distinct from the `gutendex.com` wrapper) is unaffected, and publishes its own official catalog as a CSV updated daily.
- Adds a local mirror of that catalog: `GutenbergCatalogClient` downloads the CSV directly from `gutenberg.org`, `GutenbergCatalogSyncService` parses it (Jackson CSV) and batch-upserts English/Text rows into a new `gutenberg_catalog_entries` table (V20 migration), computing each entry's cover/content URLs against `gutenberg.org` (verified reliable against dozens of real IDs). Runs once at startup if empty, then daily at 4am; failures are logged and swallowed.
- `ExternalBookService.searchExternalBooks`/`getExternalBook` now query the local catalog first (fast, always available, genuinely readable) and only fall through to live Gutendex then Open Library if there's no local match. `importGutendexBook` is unchanged - it now just resolves to a `gutenberg.org` content URL for locally-sourced books, so reading actually works again.

## Test plan
- [x] New/updated unit tests: `ExternalBookServiceTest` (13/13), `GutenbergCatalogSyncServiceTest` (6/6), `GutenbergCatalogClientTest` (2/2)
- [x] Full suite: 225 tests, 0 failures (5 pre-existing Testcontainers errors, unrelated - no local Docker daemon)
- [x] Validated the CSV parser against the real ~90k-row catalog before committing (61,369 English/Text entries parsed cleanly, spot-checked against a known title/ID) - not just small hand-written fixtures
- [ ] After merge + deploy, confirm the catalog syncs on first startup and discovery shows real, readable books