### PR TITLE
feat(auth): add Google Sign-In (POST /auth/google)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-csv</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.google.api-client</groupId>
+			<artifactId>google-api-client</artifactId>
+			<version>2.8.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/plumora/api/shared/security/GoogleIdTokenVerifierService.java
+++ b/src/main/java/com/plumora/api/shared/security/GoogleIdTokenVerifierService.java
@@ -1,0 +1,68 @@
+package com.plumora.api.shared.security;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * Verifies Google Sign-In ID tokens sent by the app (mobile/web Google Sign-In SDK) directly
+ * against Google's public keys - no server-to-server call using a client secret, and no
+ * dependency on any Google API being reachable beyond the one-time (then cached) key fetch.
+ */
+@Service
+public class GoogleIdTokenVerifierService {
+
+	private static final Logger log = LoggerFactory.getLogger(GoogleIdTokenVerifierService.class);
+
+	private final GoogleIdTokenVerifier verifier;
+
+	public GoogleIdTokenVerifierService(@Value("${app.security.google.client-id:}") String clientId) {
+		this.verifier = StringUtils.hasText(clientId)
+			? new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), GsonFactory.getDefaultInstance())
+				.setAudience(Collections.singletonList(clientId))
+				.build()
+			: null;
+	}
+
+	public boolean isConfigured() {
+		return verifier != null;
+	}
+
+	public Optional<GoogleIdentity> verify(String idTokenString) {
+		if (verifier == null || !StringUtils.hasText(idTokenString)) {
+			return Optional.empty();
+		}
+		try {
+			GoogleIdToken idToken = verifier.verify(idTokenString);
+			if (idToken == null) {
+				return Optional.empty();
+			}
+			GoogleIdToken.Payload payload = idToken.getPayload();
+			if (!StringUtils.hasText(payload.getEmail()) || !Boolean.TRUE.equals(payload.getEmailVerified())) {
+				return Optional.empty();
+			}
+			return Optional.of(new GoogleIdentity(
+				payload.getEmail().toLowerCase(),
+				(String) payload.get("given_name"),
+				(String) payload.get("family_name"),
+				(String) payload.get("picture")
+			));
+		} catch (GeneralSecurityException | IOException | IllegalArgumentException exception) {
+			log.warn("Google ID token verification failed", exception);
+			return Optional.empty();
+		}
+	}
+
+	public record GoogleIdentity(String email, String firstName, String lastName, String pictureUrl) {
+	}
+}

--- a/src/main/java/com/plumora/api/shared/security/SecurityConfig.java
+++ b/src/main/java/com/plumora/api/shared/security/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
 			)
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-				.requestMatchers(HttpMethod.POST, "/auth/register", "/auth/login").permitAll()
+				.requestMatchers(HttpMethod.POST, "/auth/register", "/auth/login", "/auth/google").permitAll()
 				.requestMatchers(HttpMethod.GET, "/catalog/**").permitAll()
 				.requestMatchers(HttpMethod.GET, "/external-books/**").permitAll()
 				.requestMatchers(HttpMethod.GET, "/uploads/**").permitAll()

--- a/src/main/java/com/plumora/api/user/application/AuthService.java
+++ b/src/main/java/com/plumora/api/user/application/AuthService.java
@@ -1,7 +1,9 @@
 package com.plumora.api.user.application;
 
 import com.plumora.api.shared.exception.DuplicateResourceException;
+import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
 import com.plumora.api.shared.exception.ResourceNotFoundException;
+import com.plumora.api.shared.security.GoogleIdTokenVerifierService;
 import com.plumora.api.shared.security.JwtService;
 import com.plumora.api.user.domain.Role;
 import com.plumora.api.user.domain.RoleName;
@@ -9,15 +11,20 @@ import com.plumora.api.user.domain.User;
 import com.plumora.api.user.infrastructure.RoleRepository;
 import com.plumora.api.user.infrastructure.UserRepository;
 import com.plumora.api.user.presentation.AuthResponse;
+import com.plumora.api.user.presentation.GoogleLoginRequest;
 import com.plumora.api.user.presentation.LoginRequest;
 import com.plumora.api.user.presentation.RegisterRequest;
 import com.plumora.api.user.presentation.UserMapper;
+import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.util.StringUtils;
 
 @Service
 public class AuthService {
@@ -27,19 +34,22 @@ public class AuthService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtService jwtService;
 	private final AuthenticationManager authenticationManager;
+	private final GoogleIdTokenVerifierService googleIdTokenVerifierService;
 
 	public AuthService(
 		UserRepository userRepository,
 		RoleRepository roleRepository,
 		PasswordEncoder passwordEncoder,
 		JwtService jwtService,
-		AuthenticationManager authenticationManager
+		AuthenticationManager authenticationManager,
+		GoogleIdTokenVerifierService googleIdTokenVerifierService
 	) {
 		this.userRepository = userRepository;
 		this.roleRepository = roleRepository;
 		this.passwordEncoder = passwordEncoder;
 		this.jwtService = jwtService;
 		this.authenticationManager = authenticationManager;
+		this.googleIdTokenVerifierService = googleIdTokenVerifierService;
 	}
 
 	@Transactional
@@ -73,6 +83,55 @@ public class AuthService {
 		User user = userRepository.findByEmail(request.email().toLowerCase())
 			.orElseThrow(() -> new ResourceNotFoundException("User was not found"));
 		return toAuthResponse(user);
+	}
+
+	@Transactional
+	public AuthResponse loginWithGoogle(GoogleLoginRequest request) {
+		if (!googleIdTokenVerifierService.isConfigured()) {
+			throw new ExternalServiceUnavailableException("Google Sign-In is not configured");
+		}
+		GoogleIdTokenVerifierService.GoogleIdentity identity = googleIdTokenVerifierService.verify(request.idToken())
+			.orElseThrow(() -> new BadCredentialsException("Invalid Google ID token"));
+
+		User user = userRepository.findByEmail(identity.email())
+			.orElseGet(() -> createUserFromGoogle(identity));
+		return toAuthResponse(user);
+	}
+
+	private User createUserFromGoogle(GoogleIdTokenVerifierService.GoogleIdentity identity) {
+		Role readerRole = roleRepository.findByName(RoleName.READER)
+			.orElseThrow(() -> new ResourceNotFoundException("Default role READER was not found"));
+
+		User user = new User();
+		user.setFirstname(StringUtils.hasText(identity.firstName()) ? identity.firstName() : "Plumora");
+		user.setLastname(StringUtils.hasText(identity.lastName()) ? identity.lastName() : "Reader");
+		user.setUsername(generateUniqueUsername(identity.email()));
+		user.setEmail(identity.email());
+		// Google-only account: never told to the user, so it can never be used to log in via
+		// /auth/login - only Google Sign-In can authenticate this account, matching the
+		// password_hash NOT NULL constraint without a schema change.
+		user.setPasswordHash(passwordEncoder.encode(UUID.randomUUID().toString()));
+		user.setAvatarUrl(identity.pictureUrl());
+		user.setRoles(Set.of(readerRole));
+		return userRepository.save(user);
+	}
+
+	private String generateUniqueUsername(String email) {
+		String local = email.substring(0, email.indexOf('@'));
+		String sanitized = local.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9_]", "");
+		String base = sanitized.length() < 3 ? "user" + sanitized : limit(sanitized, 40);
+
+		String candidate = base;
+		int suffix = 1;
+		while (userRepository.existsByUsername(candidate)) {
+			suffix++;
+			candidate = limit(base, 45) + suffix;
+		}
+		return candidate;
+	}
+
+	private String limit(String value, int maxLength) {
+		return value.length() <= maxLength ? value : value.substring(0, maxLength);
 	}
 
 	private AuthResponse toAuthResponse(User user) {

--- a/src/main/java/com/plumora/api/user/presentation/AuthController.java
+++ b/src/main/java/com/plumora/api/user/presentation/AuthController.java
@@ -35,6 +35,11 @@ public class AuthController {
 		return authService.login(request);
 	}
 
+	@PostMapping("/google")
+	public AuthResponse loginWithGoogle(@Valid @RequestBody GoogleLoginRequest request) {
+		return authService.loginWithGoogle(request);
+	}
+
 	@GetMapping("/me")
 	public UserResponse me(Principal principal) {
 		return UserMapper.toResponse(userService.getCurrentUser(principal.getName()));

--- a/src/main/java/com/plumora/api/user/presentation/GoogleLoginRequest.java
+++ b/src/main/java/com/plumora/api/user/presentation/GoogleLoginRequest.java
@@ -1,0 +1,8 @@
+package com.plumora.api.user.presentation;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GoogleLoginRequest(
+	@NotBlank String idToken
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,11 @@ app:
     jwt:
       secret: ${JWT_SECRET:change-me-for-local-development-only}
       expiration: ${JWT_EXPIRATION:86400000}
+    google:
+      # Not secret (unlike a Google "client secret", which this app never needs: ID tokens are
+      # verified locally against Google's public keys, no server-to-server call to Google using
+      # credentials). Empty by default; POST /auth/google returns 503 until it's configured.
+      client-id: ${GOOGLE_OAUTH_CLIENT_ID:}
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:*,http://127.0.0.1:*}
 

--- a/src/test/java/com/plumora/api/shared/security/GoogleIdTokenVerifierServiceTest.java
+++ b/src/test/java/com/plumora/api/shared/security/GoogleIdTokenVerifierServiceTest.java
@@ -1,0 +1,44 @@
+package com.plumora.api.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class GoogleIdTokenVerifierServiceTest {
+
+	@Test
+	void isConfiguredReturnsFalseWithoutAClientId() {
+		GoogleIdTokenVerifierService service = new GoogleIdTokenVerifierService("");
+
+		assertThat(service.isConfigured()).isFalse();
+	}
+
+	@Test
+	void isConfiguredReturnsTrueWithAClientId() {
+		GoogleIdTokenVerifierService service = new GoogleIdTokenVerifierService("test-client-id.apps.googleusercontent.com");
+
+		assertThat(service.isConfigured()).isTrue();
+	}
+
+	@Test
+	void verifyReturnsEmptyWithoutMakingAnyCallWhenNotConfigured() {
+		GoogleIdTokenVerifierService service = new GoogleIdTokenVerifierService("");
+
+		assertThat(service.verify("any-token")).isEmpty();
+	}
+
+	@Test
+	void verifyReturnsEmptyForABlankToken() {
+		GoogleIdTokenVerifierService service = new GoogleIdTokenVerifierService("test-client-id.apps.googleusercontent.com");
+
+		assertThat(service.verify("  ")).isEmpty();
+		assertThat(service.verify(null)).isEmpty();
+	}
+
+	@Test
+	void verifyReturnsEmptyForAStructurallyInvalidToken() {
+		GoogleIdTokenVerifierService service = new GoogleIdTokenVerifierService("test-client-id.apps.googleusercontent.com");
+
+		assertThat(service.verify("this-is-not-a-jwt")).isEmpty();
+	}
+}

--- a/src/test/java/com/plumora/api/user/application/AuthServiceTest.java
+++ b/src/test/java/com/plumora/api/user/application/AuthServiceTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.plumora.api.shared.exception.DuplicateResourceException;
+import com.plumora.api.shared.exception.ExternalServiceUnavailableException;
+import com.plumora.api.shared.security.GoogleIdTokenVerifierService;
 import com.plumora.api.shared.security.JwtService;
 import com.plumora.api.user.domain.Role;
 import com.plumora.api.user.domain.RoleName;
@@ -14,6 +17,7 @@ import com.plumora.api.user.domain.User;
 import com.plumora.api.user.infrastructure.RoleRepository;
 import com.plumora.api.user.infrastructure.UserRepository;
 import com.plumora.api.user.presentation.AuthResponse;
+import com.plumora.api.user.presentation.GoogleLoginRequest;
 import com.plumora.api.user.presentation.LoginRequest;
 import com.plumora.api.user.presentation.RegisterRequest;
 import java.util.Optional;
@@ -26,6 +30,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,11 +51,16 @@ class AuthServiceTest {
 	@Mock
 	private AuthenticationManager authenticationManager;
 
+	@Mock
+	private GoogleIdTokenVerifierService googleIdTokenVerifierService;
+
 	private AuthService authService;
 
 	@BeforeEach
 	void setUp() {
-		authService = new AuthService(userRepository, roleRepository, passwordEncoder, jwtService, authenticationManager);
+		authService = new AuthService(
+			userRepository, roleRepository, passwordEncoder, jwtService, authenticationManager, googleIdTokenVerifierService
+		);
 	}
 
 	@Test
@@ -121,6 +131,109 @@ class AuthServiceTest {
 		verify(authenticationManager).authenticate(any());
 		assertThat(response.token()).isEqualTo("jwt-token");
 		assertThat(response.user().email()).isEqualTo("ana@example.com");
+	}
+
+	@Test
+	void loginWithGoogleReturnsTokenForAnExistingUserMatchedByEmail() {
+		GoogleLoginRequest request = new GoogleLoginRequest("valid-id-token");
+		User existing = new User();
+		existing.setId(UUID.randomUUID());
+		existing.setEmail("ana@example.com");
+		existing.setRoles(Set.of(role(RoleName.READER)));
+		GoogleIdTokenVerifierService.GoogleIdentity identity = new GoogleIdTokenVerifierService.GoogleIdentity(
+			"ana@example.com", "Ana", "Martin", "https://example.test/pic.jpg"
+		);
+
+		when(googleIdTokenVerifierService.isConfigured()).thenReturn(true);
+		when(googleIdTokenVerifierService.verify("valid-id-token")).thenReturn(Optional.of(identity));
+		when(userRepository.findByEmail("ana@example.com")).thenReturn(Optional.of(existing));
+		when(jwtService.generateToken(existing)).thenReturn("jwt-token");
+
+		AuthResponse response = authService.loginWithGoogle(request);
+
+		assertThat(response.token()).isEqualTo("jwt-token");
+		verify(userRepository, org.mockito.Mockito.never()).save(any(User.class));
+	}
+
+	@Test
+	void loginWithGoogleCreatesANewReaderAccountWhenNoUserMatchesTheEmail() {
+		GoogleLoginRequest request = new GoogleLoginRequest("valid-id-token");
+		GoogleIdTokenVerifierService.GoogleIdentity identity = new GoogleIdTokenVerifierService.GoogleIdentity(
+			"new.reader@example.com", "New", "Reader", "https://example.test/pic.jpg"
+		);
+		Role reader = role(RoleName.READER);
+
+		when(googleIdTokenVerifierService.isConfigured()).thenReturn(true);
+		when(googleIdTokenVerifierService.verify("valid-id-token")).thenReturn(Optional.of(identity));
+		when(userRepository.findByEmail("new.reader@example.com")).thenReturn(Optional.empty());
+		when(userRepository.existsByUsername("newreader")).thenReturn(false);
+		when(roleRepository.findByName(RoleName.READER)).thenReturn(Optional.of(reader));
+		when(passwordEncoder.encode(any())).thenReturn("random-hash");
+		when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+			User user = invocation.getArgument(0);
+			user.setId(UUID.randomUUID());
+			return user;
+		});
+		when(jwtService.generateToken(any(User.class))).thenReturn("jwt-token");
+
+		authService.loginWithGoogle(request);
+
+		ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+		verify(userRepository).save(userCaptor.capture());
+		User created = userCaptor.getValue();
+		assertThat(created.getEmail()).isEqualTo("new.reader@example.com");
+		assertThat(created.getUsername()).isEqualTo("newreader");
+		assertThat(created.getFirstname()).isEqualTo("New");
+		assertThat(created.getLastname()).isEqualTo("Reader");
+		assertThat(created.getAvatarUrl()).isEqualTo("https://example.test/pic.jpg");
+		assertThat(created.getPasswordHash()).isEqualTo("random-hash");
+		assertThat(created.getRoles()).extracting(Role::getName).containsExactly(RoleName.READER);
+	}
+
+	@Test
+	void loginWithGoogleAppendsASuffixWhenTheDerivedUsernameIsTaken() {
+		GoogleLoginRequest request = new GoogleLoginRequest("valid-id-token");
+		GoogleIdTokenVerifierService.GoogleIdentity identity = new GoogleIdTokenVerifierService.GoogleIdentity(
+			"ana@example.com", "Ana", "Martin", null
+		);
+
+		when(googleIdTokenVerifierService.isConfigured()).thenReturn(true);
+		when(googleIdTokenVerifierService.verify("valid-id-token")).thenReturn(Optional.of(identity));
+		when(userRepository.findByEmail("ana@example.com")).thenReturn(Optional.empty());
+		when(userRepository.existsByUsername("ana")).thenReturn(true);
+		when(userRepository.existsByUsername("ana2")).thenReturn(false);
+		when(roleRepository.findByName(RoleName.READER)).thenReturn(Optional.of(role(RoleName.READER)));
+		when(passwordEncoder.encode(any())).thenReturn("random-hash");
+		when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(jwtService.generateToken(any(User.class))).thenReturn("jwt-token");
+
+		authService.loginWithGoogle(request);
+
+		ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+		verify(userRepository).save(userCaptor.capture());
+		assertThat(userCaptor.getValue().getUsername()).isEqualTo("ana2");
+	}
+
+	@Test
+	void loginWithGoogleRejectsAnInvalidToken() {
+		GoogleLoginRequest request = new GoogleLoginRequest("bad-token");
+		when(googleIdTokenVerifierService.isConfigured()).thenReturn(true);
+		when(googleIdTokenVerifierService.verify("bad-token")).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> authService.loginWithGoogle(request))
+			.isInstanceOf(BadCredentialsException.class);
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
+	void loginWithGoogleFailsWhenGoogleSignInIsNotConfigured() {
+		GoogleLoginRequest request = new GoogleLoginRequest("any-token");
+		when(googleIdTokenVerifierService.isConfigured()).thenReturn(false);
+
+		assertThatThrownBy(() -> authService.loginWithGoogle(request))
+			.isInstanceOf(ExternalServiceUnavailableException.class)
+			.hasMessage("Google Sign-In is not configured");
+		verifyNoInteractions(userRepository);
 	}
 
 	private Role role(RoleName roleName) {


### PR DESCRIPTION
## Summary
- New `POST /auth/google` endpoint (`{"idToken": "..."}`) - the app's Google Sign-In SDK produces an ID token client-side, this endpoint verifies it directly against Google's public keys (`GoogleIdTokenVerifier`, audience = the configured OAuth client ID) and returns the same `AuthResponse` shape as `/auth/login`/`/auth/register`. No server-to-server call to Google, no client secret needed or stored anywhere.
- Matches an existing user by the token's verified email, or creates a new `READER` account: username derived from the email local-part (sanitized, de-duplicated on collision), avatar from the Google profile picture, and a random password hash the user is never told (so the account can only ever be reached via Google Sign-In, not `/auth/login` - avoids a `password_hash` schema change).
- New `app.security.google.client-id` config (`GOOGLE_OAUTH_CLIENT_ID` env var - not secret, unlike a client secret, which this flow never needs). `POST /auth/google` returns `503` until it's configured; an invalid token or unverified email returns the same `401` as a bad password.

## Test plan
- [x] `AuthServiceTest` (9/9, including 5 new Google Sign-In cases) and new `GoogleIdTokenVerifierServiceTest` (5/5) pass
- [x] Full suite: 235 tests, 0 failures (5 pre-existing Testcontainers errors, unrelated - no local Docker daemon)
- [ ] After merge + deploy, set `GOOGLE_OAUTH_CLIENT_ID` on the VPS and confirm the frontend's "Connexion avec Google" button works end-to-end