### PR TITLE
fix(deploy): pass GOOGLE_OAUTH_CLIENT_ID through to the backend container

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -44,6 +44,11 @@ GEMINI_MAX_INPUT_CHARS=12000
 # Obligatoire. Origines exactes autorisees a appeler l'API, separees par des virgules.
 CORS_ALLOWED_ORIGINS=https://app.plumora.fr
 
+# Optionnel. Client ID OAuth Google (console.cloud.google.com, PAS le client secret - jamais
+# necessaire ici). Laisser vide desactive POST /auth/google (renvoie 503) sans affecter le
+# reste de l'application.
+GOOGLE_OAUTH_CLIENT_ID=
+
 # --- Domaines (Caddy) ---
 # Domaine racine (apex, sans sous-domaine) : redirige vers APP_DOMAIN, comme WWW_DOMAIN.
 ROOT_DOMAIN=plumora.fr

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -542,9 +542,10 @@ n'est qu'une automatisation de cette meme procedure manuelle, jamais un chemin d
 est absente de `.env`.
 
 Le reste (`COMPOSE_PROJECT_NAME`, `POSTGRES_DB`, `POSTGRES_USER`,
-`SPRING_PROFILES_ACTIVE`, `JWT_EXPIRATION`, `AI_PROVIDER`, `GEMINI_*`, `WWW_DOMAIN`,
-`ROOT_DOMAIN`, `BACKUP_RETENTION_DAYS`, `BACKUP_DIR`, `BACKUP_S3_BUCKET`) a une valeur par
-defaut raisonnable si absent de `.env` — voir [`.env.example`](.env.example) pour le detail.
+`SPRING_PROFILES_ACTIVE`, `JWT_EXPIRATION`, `AI_PROVIDER`, `GEMINI_*`, `GOOGLE_OAUTH_CLIENT_ID`,
+`WWW_DOMAIN`, `ROOT_DOMAIN`, `BACKUP_RETENTION_DAYS`, `BACKUP_DIR`, `BACKUP_S3_BUCKET`) a une
+valeur par defaut raisonnable si absent de `.env` — voir [`.env.example`](.env.example) pour le
+detail.
 
 ## Premier deploiement : commandes exactes
 
@@ -571,3 +572,6 @@ docker compose --env-file .env -f compose.prod.yml config --quiet && echo OK
 - `CORS_ALLOWED_ORIGINS`, `APP_DOMAIN`, `API_DOMAIN`, `WWW_DOMAIN`, `ROOT_DOMAIN` — confirmer
   qu'ils correspondent exactement aux domaines DNS reellement pointes vers ce VPS.
 - `CADDY_ACME_EMAIL` — adresse email reelle pour les notifications Let's Encrypt.
+- `GOOGLE_OAUTH_CLIENT_ID` — optionnel ; Client ID OAuth Google (jamais le client secret, non
+  necessaire) pour activer `POST /auth/google`. Laisser vide desactive uniquement cet endpoint
+  (503), sans affecter le reste de l'application.

--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -39,6 +39,7 @@ services:
       GEMINI_TIMEOUT_SECONDS: ${GEMINI_TIMEOUT_SECONDS:-30}
       GEMINI_MAX_INPUT_CHARS: ${GEMINI_MAX_INPUT_CHARS:-12000}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:?CORS_ALLOWED_ORIGINS is required}
+      GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID:-}
       PLUMORA_UPLOAD_DIR: /app/uploads
     volumes:
       # The only volume the backend genuinely needs: uploaded book covers must survive restarts


### PR DESCRIPTION
## Summary
- `compose.prod.yml`'s `backend` service never listed `GOOGLE_OAUTH_CLIENT_ID` under `environment:`, so it was silently absent inside the container regardless of `.env` - confirmed live on the VPS: `POST /auth/google` kept returning `503 "Google Sign-In is not configured"` even after setting the value in `.env` and redeploying the new backend image.
- Adds the passthrough (optional, empty default - matches `GEMINI_API_KEY`'s pattern), documents it in `.env.example` and `deploy/README.md`.
- No application code change - just wires the already-existing `.env` value through to the container.

## Test plan
- [ ] After merge, `git pull` + restart the `backend` service on the VPS (no new image needed) and confirm `POST /auth/google` with an invalid token now returns `401` instead of `503`